### PR TITLE
add ci worklofw to check clusterpedia crd whether been update

### DIFF
--- a/.github/workflows/lint-crd-sync.yaml
+++ b/.github/workflows/lint-crd-sync.yaml
@@ -1,0 +1,45 @@
+# validate any chart changes under charts directory
+name: Clusterpedia crd sync
+
+env:
+  CLUSTERPEDIA_REPO: https://github.com/clusterpedia-io/clusterpedia.git
+  TMP_DIR: /tmp/clusterpedia
+  CLUSTERPEDIA_CRD_DIR: deploy/crds
+  CLSUTERPEDIA_HELM_CRD_DIR: charts/clusterpedia/_crds
+  CHART_YAML_PATH: charts/clusterpedia/Chart.yaml
+  IGNORE_MATCHING_LINES: "helm.sh/resource-policy: keep"
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  crd-sync-check:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Lookup clusterpedia version
+      run: |
+        APP_VERSION=$(yq '.appVersion' < ${{ env.CHART_YAML_PATH }})
+        echo "APP_VERSION=${APP_VERSION,,}" >> ${GITHUB_ENV}
+    - name: Pull clusterpedia code
+      run: |
+        echo "chart appVersion: ${{ env.APP_VERSION }}"
+        echo "pull clusterpedia from https://github.com/clusterpedia-io/clusterpedia.git"
+        git clone --single-branch --depth 1 --branch ${{ env.APP_VERSION }} ${{ env.CLUSTERPEDIA_REPO }} ${{ env.TMP_DIR }}
+    - name: check whether crd is sync 
+      run: |
+        ret=0
+        diff -Naupr -I '${{ env.IGNORE_MATCHING_LINES }}' ${{ env.CLSUTERPEDIA_HELM_CRD_DIR }} ${{ env.TMP_DIR }}/${{ env.CLUSTERPEDIA_CRD_DIR }} || ret=$?
+        if [[ $ret -eq 1 ]]
+        then
+          echo "clusterpedia crd has been change, please update synchronouly this repo crd resource."
+          exit 1
+        fi
+    - name: cleanup
+      run: |
+        echo "remove clusterpedia code"
+        rm ${{ env.TMP_DIR }} -rf


### PR DESCRIPTION
Signed-off-by: calvin <wen.chen@daocloud.io>

**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
if the crd resource of clusterpedia main repo has been update, we need to check the change.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
