### PR TITLE
Update PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,9 +4,9 @@ If the DCO action in the integration test fails, one or more of your commits are
 
 Checklist:
 
-* [ ] I have bumped the chart version according to [versioning](https://github.com/clusterpedia/clusterpedia-helm/blob/main/CONTRIBUTING.md#versioning)
-* [ ] I have updated the documentation according to [documentation](https://github.com/clusterpedia/clusterpedia-helm/blob/main/CONTRIBUTING.md#documentation)
+* [ ] I have bumped the chart version according to [versioning](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md#versioning)
+* [ ] I have updated the documentation according to [documentation](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md#documentation)
 * [ ] Any new values are backwards compatible and/or have sensible default.
-* [ ] I have signed off all my commits as required by [DCO](https://github.com/clusterpedia/clusterpedia-helm/blob/main/CONTRIBUTING.md).
+* [ ] I have signed off all my commits as required by [DCO](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md).
 
 Changes are automatically published when merged to `main`. They are not published on branches.


### PR DESCRIPTION
fix the url path of [versioning]、[documentation]、[DCO] error

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/clusterpedia/clusterpedia-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/clusterpedia/clusterpedia-helm/blob/main/CONTRIBUTING.md#documentation)
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/clusterpedia/clusterpedia-helm/blob/main/CONTRIBUTING.md).

Changes are automatically published when merged to `main`. They are not published on branches.
