### PR TITLE
separate core chart from clusterpedia

### DIFF
--- a/.github/workflows/lint-chart.yaml
+++ b/.github/workflows/lint-chart.yaml
@@ -12,7 +12,7 @@ on:
   push:
   pull_request:
     paths:
-      - "charts/clusterpedia/**"
+      - "charts/**"
 
 jobs:
   chart-lint-test:

--- a/charts/clusterpedia-core/.helmignore
+++ b/charts/clusterpedia-core/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/clusterpedia-core/Chart.lock
+++ b/charts/clusterpedia-core/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.17.1
+digest: sha256:91bdebcf473f5da3c018dd74f25fab166d4faaa6be86d492f5caa50fc63f93fb
+generated: "2022-11-24T10:42:29.705512+08:00"

--- a/charts/clusterpedia-core/Chart.yaml
+++ b/charts/clusterpedia-core/Chart.yaml
@@ -1,0 +1,37 @@
+apiVersion: v2
+name: clusterpedia-core
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.0.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "v0.6.0"
+
+sources:
+  - "https://github.com/clusterpedia-io/clusterpedia-helm"
+
+maintainers:
+  - name: clusterpedia-io
+    url: https://github.com/clusterpedia-io/clusterpedia-helm
+
+# This is clusterpedia dependencies
+dependencies:
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    version: 1.x.x

--- a/charts/clusterpedia-core/_crds/cluster.clusterpedia.io_clustersyncresources.yaml
+++ b/charts/clusterpedia-core/_crds/cluster.clusterpedia.io_clustersyncresources.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.10.0
+    helm.sh/resource-policy: keep
+  creationTimestamp: null
+  name: clustersyncresources.cluster.clusterpedia.io
+spec:
+  group: cluster.clusterpedia.io
+  names:
+    kind: ClusterSyncResources
+    listKind: ClusterSyncResourcesList
+    plural: clustersyncresources
+    singular: clustersyncresources
+  scope: Cluster
+  versions:
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              syncResources:
+                items:
+                  properties:
+                    group:
+                      type: string
+                    resources:
+                      items:
+                        type: string
+                      minItems: 1
+                      type: array
+                    versions:
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - group
+                  - resources
+                  type: object
+                type: array
+            required:
+            - syncResources
+            type: object
+        type: object
+    served: true
+    storage: true

--- a/charts/clusterpedia-core/_crds/cluster.clusterpedia.io_pediaclusters.yaml
+++ b/charts/clusterpedia-core/_crds/cluster.clusterpedia.io_pediaclusters.yaml
@@ -1,0 +1,241 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.10.0
+    helm.sh/resource-policy: keep
+  creationTimestamp: null
+  name: pediaclusters.cluster.clusterpedia.io
+spec:
+  group: cluster.clusterpedia.io
+  names:
+    kind: PediaCluster
+    listKind: PediaClusterList
+    plural: pediaclusters
+    singular: pediacluster
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type == 'Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.apiserver
+      name: APIServer
+      type: string
+    - jsonPath: .status.conditions[?(@.type == 'Validated')].reason
+      name: Validated
+      priority: 10
+      type: string
+    - jsonPath: .status.conditions[?(@.type == 'SynchroRunning')].reason
+      name: SynchroRunning
+      priority: 10
+      type: string
+    - jsonPath: .status.conditions[?(@.type == 'ClusterHealthy')].reason
+      name: ClusterHealthy
+      priority: 10
+      type: string
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              apiserver:
+                type: string
+              caData:
+                format: byte
+                type: string
+              certData:
+                format: byte
+                type: string
+              keyData:
+                format: byte
+                type: string
+              kubeconfig:
+                format: byte
+                type: string
+              syncAllCustomResources:
+                type: boolean
+              syncResources:
+                items:
+                  properties:
+                    group:
+                      type: string
+                    resources:
+                      items:
+                        type: string
+                      minItems: 1
+                      type: array
+                    versions:
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - group
+                  - resources
+                  type: object
+                type: array
+              syncResourcesRefName:
+                type: string
+              tokenData:
+                format: byte
+                type: string
+            required:
+            - syncResources
+            type: object
+          status:
+            properties:
+              apiserver:
+                type: string
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              syncResources:
+                items:
+                  properties:
+                    group:
+                      type: string
+                    resources:
+                      items:
+                        properties:
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                          namespaced:
+                            type: boolean
+                          syncConditions:
+                            items:
+                              properties:
+                                lastTransitionTime:
+                                  format: date-time
+                                  type: string
+                                message:
+                                  description: optional
+                                  type: string
+                                reason:
+                                  description: optional
+                                  type: string
+                                status:
+                                  type: string
+                                storageResource:
+                                  description: optional
+                                  type: string
+                                storageVersion:
+                                  description: optional
+                                  type: string
+                                syncResource:
+                                  description: optional
+                                  type: string
+                                syncVersion:
+                                  description: optional
+                                  type: string
+                                version:
+                                  type: string
+                              required:
+                              - lastTransitionTime
+                              - status
+                              - version
+                              type: object
+                            type: array
+                        required:
+                        - kind
+                        - name
+                        - namespaced
+                        - syncConditions
+                        type: object
+                      type: array
+                  required:
+                  - group
+                  - resources
+                  type: object
+                type: array
+              version:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/clusterpedia-core/_crds/policy.clusterpedia.io_clusterimportpolicies.yaml
+++ b/charts/clusterpedia-core/_crds/policy.clusterpedia.io_clusterimportpolicies.yaml
@@ -1,0 +1,174 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.10.0
+    helm.sh/resource-policy: keep
+  creationTimestamp: null
+  name: clusterimportpolicies.policy.clusterpedia.io
+spec:
+  group: policy.clusterpedia.io
+  names:
+    kind: ClusterImportPolicy
+    listKind: ClusterImportPolicyList
+    plural: clusterimportpolicies
+    singular: clusterimportpolicy
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type == 'Validated')].reason
+      name: Validated
+      type: string
+    - jsonPath: .status.conditions[?(@.type == 'Reconciling')].reason
+      name: Reconciling
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              creationCondition:
+                type: string
+              nameTemplate:
+                type: string
+              references:
+                items:
+                  properties:
+                    group:
+                      type: string
+                    key:
+                      type: string
+                    nameTemplate:
+                      type: string
+                    namespaceTemplate:
+                      type: string
+                    resource:
+                      type: string
+                    versions:
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - group
+                  - key
+                  - nameTemplate
+                  - resource
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - key
+                x-kubernetes-list-type: map
+              source:
+                properties:
+                  group:
+                    type: string
+                  resource:
+                    type: string
+                  selectorTemplate:
+                    type: string
+                  versions:
+                    items:
+                      type: string
+                    type: array
+                required:
+                - group
+                - resource
+                type: object
+              template:
+                type: string
+            required:
+            - creationCondition
+            - nameTemplate
+            - source
+            - template
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/clusterpedia-core/_crds/policy.clusterpedia.io_pediaclusterlifecycles.yaml
+++ b/charts/clusterpedia-core/_crds/policy.clusterpedia.io_pediaclusterlifecycles.yaml
@@ -1,0 +1,192 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.10.0
+    helm.sh/resource-policy: keep
+  creationTimestamp: null
+  name: pediaclusterlifecycles.policy.clusterpedia.io
+spec:
+  group: policy.clusterpedia.io
+  names:
+    kind: PediaClusterLifecycle
+    listKind: PediaClusterLifecycleList
+    plural: pediaclusterlifecycles
+    singular: pediaclusterlifecycle
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type == 'Created')].reason
+      name: Created
+      type: string
+    - jsonPath: .status.conditions[?(@.type == 'Updating')].reason
+      name: Updating
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              creationCondition:
+                type: string
+              references:
+                items:
+                  properties:
+                    group:
+                      type: string
+                    key:
+                      type: string
+                    nameTemplate:
+                      type: string
+                    namespaceTemplate:
+                      type: string
+                    resource:
+                      type: string
+                    version:
+                      type: string
+                  required:
+                  - group
+                  - key
+                  - nameTemplate
+                  - resource
+                  - version
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - key
+                x-kubernetes-list-type: map
+              source:
+                properties:
+                  group:
+                    type: string
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                  resource:
+                    type: string
+                  version:
+                    type: string
+                required:
+                - group
+                - name
+                - resource
+                - version
+                type: object
+              template:
+                type: string
+            required:
+            - creationCondition
+            - source
+            - template
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              references:
+                items:
+                  properties:
+                    group:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                    resource:
+                      type: string
+                    version:
+                      type: string
+                  required:
+                  - group
+                  - name
+                  - resource
+                  - version
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/clusterpedia-core/templates/NOTES.txt
+++ b/charts/clusterpedia-core/templates/NOTES.txt
@@ -1,0 +1,21 @@
+Thank you for installing {{ .Chart.Name }}.
+
+Your release is named {{ .Release.Name }}.
+
+To learn more about the release, try:
+
+  $ helm status {{ .Release.Name }}
+  $ helm get all {{ .Release.Name }}
+
+Documentation: https://clusterpedia.io/docs/
+
+View imported clusters:
+  $ kubectl get pediacluster
+
+  Lean More -> https://clusterpedia.io/docs/usage/import-clusters/
+
+Configure the cluster shortcut for kubectl:
+  $ curl -sfL https://raw.githubusercontent.com/clusterpedia-io/clusterpedia/main/hack/gen-clusterconfigs.sh | sh -
+  $ kubectl --cluster clusterpedia api-resources
+
+  Lean More -> https://clusterpedia.io/docs/usage/access-clusterpedia/#configure-the-cluster-shortcut-for-kubectl

--- a/charts/clusterpedia-core/templates/_helpers.tpl
+++ b/charts/clusterpedia-core/templates/_helpers.tpl
@@ -1,0 +1,89 @@
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+
+{{- define "clusterpedia.apiserver.fullname" -}}
+{{- printf "%s-%s" (include "common.names.fullname" .) "apiserver" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "clusterpedia.clustersynchroManager.fullname" -}}
+{{- printf "%s-%s" (include "common.names.fullname" .) "clustersynchro-manager" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "clusterpedia.controllerManager.fullname" -}}
+{{- printf "%s-%s" (include "common.names.fullname" .) "controller-manager" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Return the proper apiserver image name
+*/}}
+{{- define "clusterpedia.apiserver.image" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.apiserver.image "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Return the proper clustersynchroManager image name
+*/}}
+{{- define "clusterpedia.clustersynchroManager.image" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.clustersynchroManager.image "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Return the proper controllerManager image name
+*/}}
+{{- define "clusterpedia.controllerManager.image" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.controllerManager.image "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Return the proper hookJob image name
+*/}}
+{{- define "clusterpedia.hookJob.image" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.hookJob.image "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "clusterpedia.apiserver.imagePullSecrets" -}}
+{{ include "common.images.pullSecrets" (dict "images" (list .Values.apiserver.image .Values.storage.initContainerImage) "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "clusterpedia.clustersynchroManager.imagePullSecrets" -}}
+{{ include "common.images.pullSecrets" (dict "images" (list .Values.clustersynchroManager.image .Values.storage.initContainerImage) "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "clusterpedia.controllerManager.imagePullSecrets" -}}
+{{ include "common.images.pullSecrets" (dict "images" (list .Values.controllerManager.image) "global" .Values.global) }}
+{{- end -}}
+
+{{- define "clusterpedia.common.featureGates" -}}
+  {{- if (not (empty .featureGates)) }}
+    {{- $featureGatesFlag := "" -}}
+    {{- range $key, $value := .featureGates }}
+      {{- if not (empty (toString $value)) }}
+        {{- $featureGatesFlag = cat $featureGatesFlag $key "=" $value "," -}}
+      {{- end }}
+    {{- end }}
+
+    {{- if gt (len $featureGatesFlag) 0 }}
+      {{- $featureGatesFlag := trimSuffix "," $featureGatesFlag  | nospace -}}
+      {{- printf "%s=%s" "--feature-gates" $featureGatesFlag -}}
+    {{- end }}
+  {{- end }}
+{{- end -}}

--- a/charts/clusterpedia-core/templates/apiserver-apiservice.yaml
+++ b/charts/clusterpedia-core/templates/apiserver-apiservice.yaml
@@ -1,0 +1,14 @@
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1beta1.clusterpedia.io
+  labels: {{ include "common.labels.standard" . | nindent 4 }}
+spec:
+  insecureSkipTLSVerify: true
+  group: clusterpedia.io
+  groupPriorityMinimum: 1000
+  versionPriority: 100
+  service:
+    name: {{ include "clusterpedia.apiserver.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+  version: v1beta1

--- a/charts/clusterpedia-core/templates/apiserver-deployment.yaml
+++ b/charts/clusterpedia-core/templates/apiserver-deployment.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "clusterpedia.apiserver.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app: {{ include "clusterpedia.apiserver.fullname" . }}
+  {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- end }}
+{{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+{{- end }}
+spec:
+  replicas: {{ .Values.apiserver.replicaCount }}
+  selector:
+    matchLabels: {{ include "common.labels.matchLabels" . | nindent 6 }}
+      app: {{ include "clusterpedia.apiserver.fullname" . }}
+  template:
+    metadata:
+    {{- if .Values.apiserver.podAnnotations }}
+      annotations: {{- include "common.tplvalues.render" (dict "value" .Values.apiserver.podAnnotations "context" $) | nindent 8 }}
+    {{- end }}
+      labels: {{ include "common.labels.standard" . | nindent 8 }}
+        app: {{ include "clusterpedia.apiserver.fullname" . }}
+      {{- if .Values.podLabels }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.apiserver.podLabels "context" $) | nindent 8 }}
+      {{- end }}
+    spec: {{ include "clusterpedia.apiserver.imagePullSecrets" . | nindent 6 }}
+    {{- if (include "clusterpedia.storage.initContainer" .) -}}
+      initContainers: {{ include "common.tplvalues.render" (dict "value" (include "clusterpedia.storage.initContainer" .) "context" $) | nindent 6 }}
+    {{- end }}
+      containers:
+      - name: {{ include "clusterpedia.apiserver.fullname" . }}
+        image: {{ template "clusterpedia.apiserver.image" . }}
+        imagePullPolicy: {{ .Values.apiserver.image.pullPolicy }}
+        command:
+        - /usr/local/bin/apiserver
+        - --secure-port=443
+        - --storage-config=/etc/clusterpedia/storage/storage-config.yaml
+        - -v=3
+      {{- if .Values.apiserver.featureGates }}
+        - {{ include "clusterpedia.common.featureGates" (dict "featureGates" .Values.apiserver.featureGates) }}
+      {{- end }}
+      {{- if .Values.apiserver.resources }}
+        resources: {{- toYaml .Values.apiserver.resources | nindent 12 }}
+      {{- end }}
+        env:
+      {{- if .Values.apiserver.enableSHA1Cert }}
+        - name: GODEBUG
+          value: x509sha1=1
+      {{- end }}
+      {{- if (include "clusterpedia.storage.env" .) }}
+        {{- include "common.tplvalues.render" (dict "value" (include "clusterpedia.storage.env" .) "context" $) | nindent 8 }}
+      {{- end }}
+        volumeMounts:
+        - name: storage-config
+          mountPath: /etc/clusterpedia/storage
+          readOnly: true
+      serviceAccountName: {{ include "clusterpedia.apiserver.fullname" . }}
+    {{- if .Values.apiserver.affinity }}
+      affinity: {{ include "common.tplvalues.render" (dict "value" .Values.apiserver.affinity "context" $) | nindent 8 }}
+    {{- end }}
+    {{- if .Values.apiserver.nodeSelector }}
+      nodeSelector: {{ include "common.tplvalues.render" (dict "value" .Values.apiserver.nodeSelector "context" $) | nindent 8 }}
+    {{- end }}
+    {{- if .Values.apiserver.tolerations }}
+      tolerations: {{ include "common.tplvalues.render" (dict "value" .Values.apiserver.tolerations "context" $) | nindent 8 }}
+    {{- end }}
+      volumes:
+      - name: storage-config
+        configMap:
+          name: {{ required "Please set configmap to storage config!" (include "clusterpedia.storage.config" .) }}

--- a/charts/clusterpedia-core/templates/apiserver-service.yaml
+++ b/charts/clusterpedia-core/templates/apiserver-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "clusterpedia.apiserver.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{ include "common.labels.standard" . | nindent 4 }}
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 443
+  selector:
+    app: {{ include "clusterpedia.apiserver.fullname" . }}
+  {{- if .Values.podLabels }}
+    {{ include "common.tplvalues.render" (dict "value" .Values.apiserver.podLabels "context" $) | nindent 4 }}
+  {{- end -}}

--- a/charts/clusterpedia-core/templates/apiserver-serviceaccount.yaml
+++ b/charts/clusterpedia-core/templates/apiserver-serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "clusterpedia.apiserver.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{ include "common.labels.standard" . | nindent 4 }}

--- a/charts/clusterpedia-core/templates/clusterrole.yaml
+++ b/charts/clusterpedia-core/templates/clusterrole.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  labels: {{ include "common.labels.standard" . | nindent 4 }}
+rules:
+  - apiGroups: ['*']
+    resources: ['*']
+    verbs: ["*"]
+  - nonResourceURLs: ['*']
+    verbs: ["get"]

--- a/charts/clusterpedia-core/templates/clusterrolebinding.yaml
+++ b/charts/clusterpedia-core/templates/clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  labels: {{ include "common.labels.standard" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "common.names.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "clusterpedia.apiserver.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: {{ include "clusterpedia.clustersynchroManager.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: {{ include "clusterpedia.controllerManager.fullname" . }}
+    namespace: {{ .Release.Namespace }}

--- a/charts/clusterpedia-core/templates/clustersynchro-manager-deployment.yaml
+++ b/charts/clusterpedia-core/templates/clustersynchro-manager-deployment.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "clusterpedia.clustersynchroManager.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app: {{ include "clusterpedia.clustersynchroManager.fullname" . }}
+  {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- end }}
+{{- if .Values.commonAnnotations }}
+  annotations: {{ include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+{{- end }}
+spec:
+  replicas: {{ .Values.clustersynchroManager.replicaCount }}
+  selector:
+    matchLabels: {{ include "common.labels.matchLabels" . | nindent 6 }}
+      app: {{ include "clusterpedia.clustersynchroManager.fullname" . }}
+  template:
+    metadata:
+    {{- if .Values.clustersynchroManager.podAnnotations }}
+      annotations: {{ include "common.tplvalues.render" (dict "value" .Values.clustersynchroManager.podAnnotations "context" $) | nindent 8 }}
+    {{- end }}
+      labels: {{ include "common.labels.standard" . | nindent 8 }}
+        app: {{ include "clusterpedia.clustersynchroManager.fullname" . }}
+      {{- if .Values.podLabels }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.clustersynchroManager.podLabels "context" $) | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- include "clusterpedia.clustersynchroManager.imagePullSecrets" . | indent 6 }}
+    {{-  if (include "clusterpedia.storage.initContainer" .) }}
+      initContainers: {{- include "common.tplvalues.render" (dict "value" (include "clusterpedia.storage.initContainer" .) "context" $) | nindent 8 }}
+    {{- end }}
+      containers:
+      - name: {{ include "clusterpedia.clustersynchroManager.fullname" . }}
+        image: {{ template "clusterpedia.clustersynchroManager.image" . }}
+        imagePullPolicy: {{ .Values.clustersynchroManager.image.pullPolicy }}
+        command:
+        - /usr/local/bin/clustersynchro-manager
+        - --storage-config=/etc/clusterpedia/storage/storage-config.yaml
+        - --leader-elect-resource-namespace={{ .Release.Namespace }}
+      {{- if .Values.storage.name }}
+        - --storage-name={{ .Values.storage.name }}
+      {{- end }}
+      {{- if .Values.clustersynchroManager.featureGates }}
+        - {{ include "clusterpedia.common.featureGates" (dict "featureGates" .Values.clustersynchroManager.featureGates) }}
+      {{- end }}
+      {{- if .Values.clustersynchroManager.resources }}
+        resources: {{- toYaml .Values.clustersynchroManager.resources | nindent 12 }}
+      {{- end }}
+        env:
+      {{- if (include "clusterpedia.storage.env" .) }}
+        {{- include "common.tplvalues.render" (dict "value" (include "clusterpedia.storage.env" .) "context" $) | nindent 8 }}
+      {{- end }}
+        volumeMounts:
+        - name: storage-config
+          mountPath: /etc/clusterpedia/storage
+          readOnly: true
+      serviceAccountName: {{ include "clusterpedia.clustersynchroManager.fullname" . }}
+      {{- if .Values.clustersynchroManager.affinity }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.clustersynchroManager.affinity "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.clustersynchroManager.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.clustersynchroManager.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.clustersynchroManager.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.clustersynchroManager.tolerations "context" $) | nindent 8 }}
+      {{- end }}
+      volumes:
+      - name: storage-config
+        configMap:
+          name: {{ required "Please set configmap to storage config!" (include "clusterpedia.storage.config" .) }}

--- a/charts/clusterpedia-core/templates/clustersynchro-manager-serviceaccount.yaml
+++ b/charts/clusterpedia-core/templates/clustersynchro-manager-serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "clusterpedia.clustersynchroManager.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{ include "common.labels.standard" . | nindent 4 }}

--- a/charts/clusterpedia-core/templates/controller-manager-deployment.yaml
+++ b/charts/clusterpedia-core/templates/controller-manager-deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "clusterpedia.controllerManager.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{ include "common.labels.standard" . | nindent 4 }}
+    app: {{ include "clusterpedia.controllerManager.fullname" . }}
+  {{- if .Values.commonLabels }}
+    {{ include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- end }}
+{{- if .Values.commonAnnotations }}
+  annotations: {{ include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+{{- end }}
+spec:
+  replicas: {{  .Values.controllerManager.replicaCount }}
+  selector:
+    matchLabels: {{ include "common.labels.matchLabels" . | nindent 6 }}
+      app: {{ include "clusterpedia.controllerManager.fullname" . }}
+  template:
+    metadata:
+    {{- if .Values.controllerManager.podAnnotations }}
+      annotations: {{ include "common.tplvalues.render" (dict "value" .Values.controllerManager.podAnnotations "context" $) | nindent 8 }}
+    {{- end }}
+      labels: {{ include "common.labels.standard" . | nindent 8 }}
+        app: {{ include "clusterpedia.controllerManager.fullname" . }}
+      {{- if .Values.podLabels }}
+        {{ include "common.tplvalues.render" (dict "value" .Values.controllerManager.podLabels "context" $) | nindent 8 }}
+      {{- end }}
+    spec: {{ include "clusterpedia.controllerManager.imagePullSecrets" . | indent 6 }}
+      containers:
+      - name: {{ include "clusterpedia.controllerManager.fullname" . }}
+        image: {{ template "clusterpedia.controllerManager.image" . }}
+        imagePullPolicy: {{ .Values.controllerManager.image.pullPolicy }}
+        command:
+        - /usr/local/bin/controller-manager
+        - --leader-elect-resource-namespace={{ .Release.Namespace }}
+      {{- if .Values.controllerManager.featureGates }}
+        - {{ include "clusterpedia.common.featureGates" (dict "featureGates" .Values.controllerManager.featureGates) }}
+      {{- end }}
+      {{- if .Values.controllerManager.resources }}
+        resources: {{ toYaml .Values.controllerManager.resources | nindent 12 }}
+      {{- end }}
+      serviceAccountName: {{ include "clusterpedia.controllerManager.fullname" . }}
+    {{- if .Values.controllerManager.affinity }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.controllerManager.affinity "context" $) | nindent 8 }}
+    {{- end }}
+    {{- if .Values.controllerManager.nodeSelector }}
+      nodeSelector: {{ include "common.tplvalues.render" (dict "value" .Values.controllerManager.nodeSelector "context" $) | nindent 8 }}
+    {{- end }}
+    {{- if .Values.controllerManager.tolerations }}
+      tolerations: {{ include "common.tplvalues.render" (dict "value" .Values.controllerManager.tolerations "context" $) | nindent 8 }}
+    {{- end -}}

--- a/charts/clusterpedia-core/templates/controller-manager-serviceaccount.yaml
+++ b/charts/clusterpedia-core/templates/controller-manager-serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "clusterpedia.controllerManager.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{ include "common.labels.standard" . | nindent 4 }}

--- a/charts/clusterpedia-core/templates/pre-hook-clusterrole.yaml
+++ b/charts/clusterpedia-core/templates/pre-hook-clusterrole.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.installCRDs -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-pre-hook-job
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: ['apiextensions.k8s.io']
+    resources: ['customresourcedefinitions']
+    verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
+  - nonResourceURLs: ['*']
+    verbs: ["get"]
+{{- end -}}

--- a/charts/clusterpedia-core/templates/pre-hook-clusterrolebinding.yaml
+++ b/charts/clusterpedia-core/templates/pre-hook-clusterrolebinding.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.installCRDs -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-pre-hook-job
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-pre-hook-job
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-pre-hook-job
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/clusterpedia-core/templates/pre-hook-crds-configmap.yaml
+++ b/charts/clusterpedia-core/templates/pre-hook-crds-configmap.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.installCRDs -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-pre-manifests
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+data:
+  crds-configmaps.yaml: |-
+      {{ range $path, $bytes := .Files.Glob (printf "_crds/*")}}
+      {{- $.Files.Get $path | nindent 8 }}
+      {{ end }}
+{{- end -}}

--- a/charts/clusterpedia-core/templates/pre-hook-job.yaml
+++ b/charts/clusterpedia-core/templates/pre-hook-job.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.installCRDs }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-apply-crds"
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "2"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      name: {{ .Release.Name }}
+      labels:
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    spec:
+      serviceAccountName: {{ .Release.Name }}-pre-hook-job
+      restartPolicy: Never
+      containers:
+      - name: install-crds
+        image: {{ include "clusterpedia.hookJob.image" . }}
+        imagePullPolicy: IfNotPresent
+        workingDir: /crds
+        command:
+        - /bin/sh
+        - -c
+        - |
+          bash <<'EOF'
+          set -ex
+          kubectl apply --server-side -f /manifests/crds-configmaps.yaml --force-conflicts
+          EOF
+        volumeMounts:
+        - name: manifests
+          mountPath: /manifests
+      volumes:
+      - name: manifests
+        configMap:
+          name: {{ .Release.Name }}-pre-manifests
+{{- end -}}

--- a/charts/clusterpedia-core/templates/pre-hook-serviceaccount.yaml
+++ b/charts/clusterpedia-core/templates/pre-hook-serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.installCRDs }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-pre-hook-job
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+{{- end -}}

--- a/charts/clusterpedia-core/values.yaml
+++ b/charts/clusterpedia-core/values.yaml
@@ -1,0 +1,209 @@
+## Default values for charts.
+## This is a YAML-formatted file.
+## Declare variables to be passed into your templates.
+
+## @param global clusterpedia global config
+global:
+  ## @param global.imageRegistry Global Docker image registry
+  imageRegistry: ""
+  ## E.g.
+  ## imagePullSecrets:
+  ##   - myRegistryKeySecretName
+  imagePullSecrets: []
+
+## @param installCRDs define flag whether to install or upgrade CRD resources
+##
+installCRDs: false
+## @param commonLabels Add labels to all the deployed resources (sub-charts are not considered). Evaluated as a template
+##
+commonLabels: {}
+## @param commonAnnotations Annotations to add to all deployed objects
+##
+commonAnnotations: {}
+
+## clusterpedia apiserver config
+apiserver:
+  ## @param apiserver.labels
+  labels: {}
+  ## @param apiserver.replicaCount target replicas
+  replicaCount: 1
+  ## @param apiserver.podAnnotations
+  podAnnotations: {}
+  ## @param apiserver.podLabels
+  podLabels: {}
+  ## @param image.registry clusterpedia apiserver image registry
+  ## @param image.repository clusterpedia apiserver image repository
+  ## @param image.tag clusterpedia apiserver image tag (immutable tags are recommended)
+  ## @param image.pullPolicy clusterpedia apiserver image pull policy
+  ## @param image.pullSecrets Specify docker-registry secret names as an array
+  ##
+  image:
+    registry: ghcr.io
+    repository: clusterpedia-io/clusterpedia/apiserver
+    tag: v0.6.0
+    ## Specify a imagePullPolicy
+    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+    ##
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## Example:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []
+  ## @param apiserver.resources
+  resources:
+    {}
+    # If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+  ## @param controllerManager.nodeSelector
+  nodeSelector: {}
+  ## @param controllerManager.affinity
+  affinity: {}
+  ## @param controllerManager.tolerations
+  ## @param apiserver.tolerations
+  tolerations: []
+  ## @param featureGate to apiserver
+  featureGates:
+    ## Allow apiservers to show a count of remaining items in the response to a chunking list request.
+    RemainingItemCount: false
+    ## @param AllowRawSQLQuery is a feature gate for the apiserver to allow querying by the raw sql.
+    ## owner: @cleverhu
+    ## alpha: v0.3.0
+    AllowRawSQLQuery: false
+  ## @param apiserver.enableSHA1Cert specifies whether to allow SHA1 certificates for apiserver.
+  enableSHA1Cert: false
+
+## clustersynchro manager config
+clustersynchroManager:
+  ## @param clustersynchroManager.labels
+  labels: {}
+  ## @param clustersynchroManager.replicaCount target replicas
+  replicaCount: 1
+  ## @param clustersynchroManager.podAnnotations
+  podAnnotations: {}
+  ## @param clustersynchroManager.podLabels
+  podLabels: {}
+  ## @param image.registry clusterpedia clustersynchroManager image registry
+  ## @param image.repository clusterpedia clustersynchroManager image repository
+  ## @param image.tag clusterpedia clustersynchroManager image tag (immutable tags are recommended)
+  ## @param image.pullPolicy clusterpedia clustersynchroManager image pull policy
+  ## @param image.pullSecrets Specify docker-registry secret names as an array
+  ##
+  image:
+    registry: ghcr.io
+    repository: clusterpedia-io/clusterpedia/clustersynchro-manager
+    tag: v0.6.0
+    ## Specify a imagePullPolicy
+    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+    ##
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## Example:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []
+  ## @param clustersynchroManager.resources
+  resources:
+    {}
+    # If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+  ## @param clustersynchroManager.nodeSelector
+  nodeSelector: {}
+  ## @param clustersynchroManager.affinity
+  affinity: {}
+  ## @param clustersynchroManager.tolerations
+  tolerations: []
+  ## @param featureGate to clustersynchro
+  featureGates:
+    ## @param PruneManagedFields is a feature gate for ClusterSynchro to prune `ManagedFields` of the resource
+    ## owner: @iceber
+    ## alpha: v0.0.9
+    ## beta: v0.3.0
+    PruneManagedFields: true
+    ## @param PruneLastAppliedConfiguration is a feature gate for the ClusterSynchro to prune `LastAppliedConfiguration` of the resource
+    ## owner: @iceber
+    ## alpha: v0.0.9
+    ## beta: v0.3.0
+    PruneLastAppliedConfiguration: true
+    ## @param AllowSyncAllCustomResources is a feature gate for the ClusterSynchro to allow syncing of all custom resources
+    ## owner: @iceber
+    ## alpha: v0.3.0
+    AllowSyncAllCustomResources: false
+    ## @param AllowSyncAllResources is a feature gate for the ClusterSynchro to allow syncing of all resources
+    ## owner: @iceber
+    ## alpha: v0.3.0
+    AllowSyncAllResources: false
+
+## controller manager config
+controllerManager:
+  ## @param controllerManager.labels
+  labels: {}
+  ## @param controllerManager.replicaCount target replicas
+  replicaCount: 1
+  ## @param controllerManager.podAnnotations
+  podAnnotations: {}
+  ## @param controllerManager.podLabels
+  podLabels: {}
+  ## @param image.registry clusterpedia controllerManager image registry
+  ## @param image.repository clusterpedia controllerManager image repository
+  ## @param image.tag clusterpedia controllerManager image tag (immutable tags are recommended)
+  ## @param image.pullPolicy clusterpedia controllerManager image pull policy
+  ## @param image.pullSecrets Specify docker-registry secret names as an array
+  ##
+  image:
+    registry: ghcr.io
+    repository: clusterpedia-io/clusterpedia/controller-manager
+    tag: v0.6.0
+    ## Specify a imagePullPolicy
+    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+    ##
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## Example:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []
+  ## @param controllerManager.resources
+  resources:
+    {}
+    # If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+  ## @param controllerManager.nodeSelector
+  nodeSelector: {}
+  ## @param controllerManager.affinity
+  affinity: {}
+  ## @param controllerManager.tolerations
+  tolerations: []
+  ## @param featureGate to controller
+  featureGates: {}
+
+hookJob:
+  image:
+    registry: ghcr.io
+    repository: cloudtty/cloudshell
+    tag: "v0.4.0"
+    pullPolicy: IfNotPresent


### PR DESCRIPTION
separate core chart from clusterpedia.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md#documentation)
* [ ] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md).

Changes are automatically published when merged to `main`. They are not published on branches.
