### PR TITLE
clusterpedia-core: support configuration of storage plugin image

### DIFF
--- a/charts/clusterpedia-core/templates/apiserver-deployment.yaml
+++ b/charts/clusterpedia-core/templates/apiserver-deployment.yaml
@@ -28,9 +28,8 @@ spec:
       {{- end }}
     spec: 
       {{- include "clusterpedia.apiserver.imagePullSecrets" . | indent 6 }}
-    {{-  if (include "clusterpedia.storage.initContainers" .) }}
-      initContainers:
-        {{- include "common.tplvalues.render" (dict "value" (include "clusterpedia.storage.initContainers" .) "context" $) | indent 8 }}
+    {{-  if (include "clusterpedia.initContainers" .) }}
+      {{- include "common.tplvalues.render" (dict "value" (include "clusterpedia.initContainers" .) "context" $) | indent 6 }}
     {{- end }}
       containers:
       - name: {{ include "clusterpedia.apiserver.fullname" . }}
@@ -45,26 +44,19 @@ spec:
       {{- if (include "clusterpedia.storage.configmap.name" .) }}
         - --storage-config=/etc/clusterpedia/storage/config.yaml
       {{- end }}
-        - -v=3
       {{- if .Values.apiserver.featureGates }}
         - {{ include "clusterpedia.common.featureGates" (dict "featureGates" .Values.apiserver.featureGates) }}
       {{- end }}
+        - -v=3
       {{- if .Values.apiserver.resources }}
         resources: {{- toYaml .Values.apiserver.resources | nindent 12 }}
       {{- end }}
       {{- if (include "clusterpedia.apiserver.env" .) -}}
         {{- include "common.tplvalues.render" (dict "value" (include "clusterpedia.apiserver.env" .) "context" $) | indent 8 }}
       {{- end -}}
-    {{- if (include "clusterpedia.storage.configmap.name" .) }}
-        volumeMounts:
-        - name: storage-config
-          mountPath: /etc/clusterpedia/storage
-          readOnly: true
-      volumes:
-      - name: storage-config
-        configMap:
-          name: {{ include "clusterpedia.storage.configmap.name" . }}
-    {{- end }}
+      {{- if (include "clusterpedia.volumeMounts" .) -}}
+        {{- include "common.tplvalues.render" (dict "value" (include "clusterpedia.volumeMounts" .) "context" $) | indent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "clusterpedia.apiserver.fullname" . }}
     {{- if .Values.apiserver.affinity }}
       affinity: {{ include "common.tplvalues.render" (dict "value" .Values.apiserver.affinity "context" $) | nindent 8 }}
@@ -74,4 +66,7 @@ spec:
     {{- end }}
     {{- if .Values.apiserver.tolerations }}
       tolerations: {{ include "common.tplvalues.render" (dict "value" .Values.apiserver.tolerations "context" $) | nindent 8 }}
+    {{- end }}
+    {{- if (include "clusterpedia.volumes" .) -}}
+      {{- include "common.tplvalues.render" (dict "value" (include "clusterpedia.volumes" .) "context" $) | indent 6 }}
     {{- end }}

--- a/charts/clusterpedia-core/templates/clustersynchro-manager-deployment.yaml
+++ b/charts/clusterpedia-core/templates/clustersynchro-manager-deployment.yaml
@@ -28,9 +28,8 @@ spec:
       {{- end }}
     spec:
       {{- include "clusterpedia.clustersynchroManager.imagePullSecrets" . | indent 6 }}
-    {{-  if (include "clusterpedia.storage.initContainers" .) }}
-      initContainers:
-        {{- include "common.tplvalues.render" (dict "value" (include "clusterpedia.storage.initContainers" .) "context" $) | indent 8 }}
+    {{-  if (include "clusterpedia.initContainers" .) }}
+      {{- include "common.tplvalues.render" (dict "value" (include "clusterpedia.initContainers" .) "context" $) | indent 6 }}
     {{- end }}
       containers:
       - name: {{ include "clusterpedia.clustersynchroManager.fullname" . }}
@@ -54,16 +53,9 @@ spec:
       {{- if (include "clusterpedia.clustersynchroManager.env" .) -}}
         {{- include "common.tplvalues.render" (dict "value" (include "clusterpedia.clustersynchroManager.env" .) "context" $) | indent 8 }}
       {{- end -}}
-    {{- if (include "clusterpedia.storage.configmap.name" .) }}
-        volumeMounts:
-        - name: storage-config
-          mountPath: /etc/clusterpedia/storage
-          readOnly: true
-      volumes:
-      - name: storage-config
-        configMap:
-          name: {{ include "clusterpedia.storage.configmap.name" . }}
-    {{- end }}
+      {{- if (include "clusterpedia.volumeMounts" .) -}}
+        {{- include "common.tplvalues.render" (dict "value" (include "clusterpedia.volumeMounts" .) "context" $) | indent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "clusterpedia.clustersynchroManager.fullname" . }}
       {{- if .Values.clustersynchroManager.affinity }}
       affinity: {{- include "common.tplvalues.render" (dict "value" .Values.clustersynchroManager.affinity "context" $) | nindent 8 }}
@@ -74,3 +66,6 @@ spec:
       {{- if .Values.clustersynchroManager.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.clustersynchroManager.tolerations "context" $) | nindent 8 }}
       {{- end }}
+    {{- if (include "clusterpedia.volumes" .) -}}
+      {{- include "common.tplvalues.render" (dict "value" (include "clusterpedia.volumes" .) "context" $) | indent 6 }}
+    {{- end }}

--- a/charts/clusterpedia-core/values.yaml
+++ b/charts/clusterpedia-core/values.yaml
@@ -213,3 +213,11 @@ storage:
   configMap: ""
   config: {}
   componentEnv: []
+  image:
+    registry: ""
+    repository: ""
+    tag: ""
+    ## Specify a imagePullPolicy
+    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+    ##
+    pullPolicy: IfNotPresent


### PR DESCRIPTION
Signed-off-by: Iceber Gu <wei.cai-nat@daocloud.io>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md#documentation)
* [ ] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md).

Changes are automatically published when merged to `main`. They are not published on branches.

You can run clusterpedia directly using core and plugin images
> Note that core does not take care of the installation and checking of the storage components

```yaml
# myvalues.yaml
apiserver:
  image:
    tag: v0.6.0-beta.1
clustersynchroManager:
  image:
    tag: v0.6.0-beta.1
controller:
  image:
    tag: v0.6.0-beta.1
storage:
  name: "sample-storage-layer"
  config:
    type: "mysql"
    host: "10.111.94.196"
    port: 3306
    user: root
    password: dangerous0
    database: clusterpedia
  image:
    registry: ghcr.io
    repository: clusterpedia-io/clusterpedia/sample-storage-layer
    tag: v0.0.0-v0.6.0-beta.1
```

```bash
helm install clusterpedia -n clusterpedia-system -f myvalues.yaml ./clusterpedia-core
```

