### PR TITLE
add mysql storage for clusterpedia

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+output
+.vscode
+.DS_Store
+.idea
+**/*.tgz
+**/charts/*/charts

--- a/charts/clusterpedia-core/templates/_helpers.tpl
+++ b/charts/clusterpedia-core/templates/_helpers.tpl
@@ -90,7 +90,7 @@ Return the proper Docker Image Registry Secret Names
 
 {{- define "clusterpedia.storage.configmap.name" -}}
 {{- if (include "clusterpedia.storage.override.configmap.name" .) }}
-  {{ include "clusterpedia.storage.override.configmap.name" . }}
+  {{- include "clusterpedia.storage.override.configmap.name" . -}}
 {{- else if .Values.storage.configmap -}}
   {{- .Values.storage.configmap -}}
 {{- else if .Values.storage.config -}}
@@ -100,7 +100,7 @@ Return the proper Docker Image Registry Secret Names
 
 {{- define "clusterpedia.storage.initContainers" -}}
 {{- if (include "clusterpedia.storage.override.initContainers" .) }}
-{{ include "clusterpedia.storage.override.initContainers" . }}
+{{- include "clusterpedia.storage.override.initContainers" . -}}
 {{- end }}
 {{- end -}}
 

--- a/charts/clusterpedia-core/values.yaml
+++ b/charts/clusterpedia-core/values.yaml
@@ -209,7 +209,7 @@ hookJob:
     pullPolicy: IfNotPresent
 
 storage:
-  name: "internalstorage"
+  name: ""
   configMap: ""
   config: {}
   componentEnv: []

--- a/charts/clusterpedia-mysql/.helmignore
+++ b/charts/clusterpedia-mysql/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/clusterpedia-mysql/Chart.lock
+++ b/charts/clusterpedia-mysql/Chart.lock
@@ -1,0 +1,12 @@
+dependencies:
+- name: mysql
+  repository: https://charts.bitnami.com/bitnami
+  version: 9.4.5
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.17.1
+- name: clusterpedia-core
+  repository: https://clusterpedia-io.github.io/clusterpedia-helm/
+  version: 0.1.0
+digest: sha256:9e2334ce4505330dbdb7d460be53b484015984adc32e77c24b89bbdc2cce96e9
+generated: "2022-12-14T17:53:48.348695+08:00"

--- a/charts/clusterpedia-mysql/Chart.yaml
+++ b/charts/clusterpedia-mysql/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: clusterpedia-core
+name: clusterpedia-mysql
 description: A Helm chart for Clusterpedia
 
 # A chart can be either an 'application' or a 'library' chart.
@@ -32,6 +32,12 @@ maintainers:
 
 # This is clusterpedia dependencies
 dependencies:
+  - name: mysql
+    repository: https://charts.bitnami.com/bitnami
+    version: 9.x.x
   - name: common
     repository: https://charts.bitnami.com/bitnami
     version: 1.x.x
+  - name: clusterpedia-core
+    repository: https://clusterpedia-io.github.io/clusterpedia-helm/
+    version: 0.1.0

--- a/charts/clusterpedia-mysql/templates/_helpers.tpl
+++ b/charts/clusterpedia-mysql/templates/_helpers.tpl
@@ -1,0 +1,81 @@
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "clusterpedia.mysql.storage.fullname" -}}
+  {{- if contains "mysql" .Release.Name }}
+    {{- printf "%s-%s" .Release.Name "storage" | trunc 63 | trimSuffix "-" -}}
+  {{- else }}
+    {{- printf "%s-%s-%s" .Release.Name "mysql" "storage" | trunc 63 | trimSuffix "-" -}}
+  {{- end }}
+{{- end -}}
+
+{{- define "clusterpedia.job.mysql.storage.pv.fullname" -}}
+  {{- printf "check-%s-local-pv-dir" (include "clusterpedia.mysql.storage.persistence.matchNode" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "clusterpedia.mysql.storage.initContainer.env.name" -}}
+  {{- printf "%s-mysql-storage-initcontainer-env" .Release.Name -}}
+{{- end -}}
+
+{{- define "clusterpedia.mysql.storage.image" -}}
+  {{- include "common.images.image" (dict "imageRoot" .Values.mysql.image "global" .Values.global) -}}
+{{- end -}}
+
+{{- define "clusterpedia.mysql.storage.user" -}}
+  {{- if eq .Values.storageInstallMode "external" }}
+    {{- required "Please set correct storage user!" .Values.externalStorage.user -}}
+  {{- else if not (empty .Values.mysql.auth.username) }}
+    {{- .Values.mysql.auth.username -}}
+  {{- else }}
+    {{- "root" -}}
+  {{- end }}
+{{- end -}}
+
+{{- define "clusterpedia.mysql.storage.password" -}}
+  {{- if eq .Values.storageInstallMode "external" }}
+    {{- required "Please set correct storage password!" .Values.externalStorage.password | b64enc -}}
+  {{- else if not (empty .Values.mysql.auth.username) }}
+    {{- .Values.mysql.auth.password  | b64enc -}}
+  {{- else }}
+    {{- .Values.mysql.auth.rootPassword | b64enc -}}
+  {{- end }}
+{{- end -}}
+
+{{/* use the default port */}}
+{{- define "clusterpedia.mysql.storage.port" -}}
+  {{- if eq .Values.storageInstallMode "external" }}
+    {{- required "Please set correct storage port!" .Values.externalStorage.port -}}
+  {{- else }}
+    {{- .Values.mysql.primary.service.ports.mysql -}}
+  {{- end }}
+{{- end -}}
+
+{{/* use the default port */}}
+{{- define "clusterpedia.mysql.storage.host" -}}
+  {{- if eq .Values.storageInstallMode "external" }}
+    {{- required "Please set correct storage host!" .Values.externalStorage.host -}}
+  {{- else }}
+    {{- "clusterpedia-mysql" -}}
+  {{- end }}
+{{- end -}}
+
+{{- define "clusterpedia.mysql.storage.database" -}}
+  {{- if eq .Values.storageInstallMode "external" }}
+    {{- if empty .Values.externalStorage.database }}
+      {{- required "Please set correct storage database!" "" -}}
+    {{- else }}
+      {{- .Values.externalStorage.database -}}
+    {{- end }}
+  {{- else }}
+    {{- "clusterpedia" -}}
+  {{- end }}
+{{- end -}}
+
+{{- define "clusterpedia.mysql.storage.persistence.matchNode" -}}
+  {{- if and (not (empty .Values.persistenceMatchNode)) (not (eq .Values.persistenceMatchNode "None")) }}
+    {{- .Values.persistenceMatchNode -}}
+  {{- else if not (eq .Values.persistenceMatchNode "None") }}
+    {{- required "Please set parameter persistenceMatchNode, if PV resources are not required, set it to None!" .Values.persistenceMatchNode -}}
+  {{- end }}
+{{- end -}}

--- a/charts/clusterpedia-mysql/templates/_storage_override.yaml
+++ b/charts/clusterpedia-mysql/templates/_storage_override.yaml
@@ -1,0 +1,37 @@
+{{- define "clusterpedia.storage.override.initContainers" -}}
+- name: ensure-database
+  image: docker.io/bitnami/mysql:8.0.28-debian-10-r23
+  command:
+  - /bin/sh
+  - -ec
+  - |
+    if [ ${CREARE_DATABASE} = "ture" ]; then
+      until mysql -u${STORAGE_USER} -p${DB_PASSWORD} --host=${STORAGE_HOST} --port=${STORAGE_PORT} -e 'CREATE DATABASE IF NOT EXISTS ${STORAGE_DATABASE}'; do
+      echo waiting for database check && sleep 1; 
+      done;
+      echo 'DataBase OK ✓'
+    else
+      until mysqladmin status -u${STORAGE_USER} -p${DB_PASSWORD} --host=${STORAGE_HOST} --port=${STORAGE_PORT}; do sleep 1; done
+    fi
+  env:
+  - name: DB_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: {{ include "clusterpedia.mysql.storage.fullname" . }}
+        key: password
+  envFrom: 
+  - configMapRef:
+      name: {{ include "clusterpedia.mysql.storage.initContainer.env.name" . }}
+{{- end -}}
+
+{{- define "clusterpedia.storage.override.configmap.name" -}}
+{{- printf "%s-mysql-storage-config" .Release.Name -}}
+{{- end -}}
+
+{{- define "clusterpedia.storage.override.componentEnv" -}}
+- name: DB_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "clusterpedia.mysql.storage.fullname" . }}
+      key: password
+{{- end -}}

--- a/charts/clusterpedia-mysql/templates/local-pv-check-job.yaml
+++ b/charts/clusterpedia-mysql/templates/local-pv-check-job.yaml
@@ -1,0 +1,40 @@
+{{- if and (include "clusterpedia.mysql.storage.persistence.matchNode" .) (eq .Values.storageInstallMode "internal") -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "clusterpedia.job.mysql.storage.pv.fullname" .}}
+  namespace: {{ .Release.Namespace }}
+  labels: {{ include "common.labels.standard" . | nindent 4 }}
+    app: {{ include "clusterpedia.mysql.storage.fullname" . }}
+    internalstorage.clusterpedia.io/type: mysql
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        app: {{ include "clusterpedia.mysql.storage.fullname" . }}
+        internalstorage.clusterpedia.io/type: mysql
+        job: check-node-local-pv-dir
+    spec:
+      restartPolicy: Never
+      nodeName: {{ include "clusterpedia.mysql.storage.persistence.matchNode" . }}
+      containers:
+      - name: check-dir
+        image: {{ include "clusterpedia.mysql.storage.image" . }}
+        command: ['sh', '-c', 'stat /bitnami/mysql']
+        volumeMounts:
+        - name: pv-dir
+          mountPath: /bitnami/mysql
+      volumes:
+      - name: pv-dir
+        hostPath:
+          path: /var/local/clusterpedia/mysqlstorage/mysql
+      tolerations:
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"
+{{- end -}}

--- a/charts/clusterpedia-mysql/templates/local-pv.yaml
+++ b/charts/clusterpedia-mysql/templates/local-pv.yaml
@@ -1,0 +1,29 @@
+{{- if and (include "clusterpedia.mysql.storage.persistence.matchNode" .) (eq .Values.storageInstallMode "internal") -}}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ include "clusterpedia.mysql.storage.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+{{- if .Values.mysql.primary.persistence.selector.matchLabels }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.mysql.primary.persistence.selector.matchLabels "context" $ ) | nindent 4 }}
+{{- end }}
+spec:
+  capacity:
+    storage: {{ .Values.mysql.primary.persistence.size }}
+  volumeMode: Filesystem
+  accessModes:
+  - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  local:
+    path: /var/local/clusterpedia/mysqlstorage/mysql
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        {{- if (include "clusterpedia.mysql.storage.persistence.matchNode" .) }}
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - {{ include "clusterpedia.mysql.storage.persistence.matchNode" . }}
+        {{- end }}
+{{- end -}}

--- a/charts/clusterpedia-mysql/templates/password-secret.yaml
+++ b/charts/clusterpedia-mysql/templates/password-secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "clusterpedia.mysql.storage.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{ include "common.labels.standard" . | nindent 4 }}
+    app: {{ include "clusterpedia.mysql.storage.fullname" . }}
+    internalstorage.clusterpedia.io/type: mysql
+data:
+  password: {{ include "clusterpedia.mysql.storage.password" . }}

--- a/charts/clusterpedia-mysql/templates/storage-config-configmap.yaml
+++ b/charts/clusterpedia-mysql/templates/storage-config-configmap.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "clusterpedia.storage.override.configmap.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{ include "common.labels.standard" . | nindent 4 }}
+data:
+  config.yaml: |-
+    type: "mysql"
+    host: {{ include "clusterpedia.mysql.storage.host" . | quote }}
+    port: {{ include "clusterpedia.mysql.storage.port" . }}
+    user: {{ include "clusterpedia.mysql.storage.user" . }}
+    database: {{ include "clusterpedia.mysql.storage.database" . }}
+    {{- if .Values.storageConfig.log.enabled }}
+    log:
+      stdout: {{ .Values.storageConfig.log.stdout }}
+      level: {{ .Values.storageConfig.log.level | default "Warn" | quote }}
+      slowThreshold: {{ .Values.storageConfig.log.slowThreshold }}
+      ignoreRecordNotFoundError: {{ .Values.storageConfig.log.ignoreRecordNotFoundError }}
+      logger:
+        filename: {{ .Values.storageConfig.log.logger.filename }}
+        maxsize: {{ .Values.storageConfig.log.logger.maxsize }}
+        maxbackups: {{ .Values.storageConfig.log.logger.maxbackups }}
+    {{- end }}
+    connPool:
+      maxIdleConns: {{ .Values.storageConfig.connPool.maxIdleConns | int }}
+      maxOpenConns: {{ .Values.storageConfig.connPool.maxOpenConns | int }}
+      connMaxLifetime: {{ .Values.storageConfig.connPool.connMaxLifetime }}

--- a/charts/clusterpedia-mysql/templates/storage-initcontainer-env-configmap.yaml
+++ b/charts/clusterpedia-mysql/templates/storage-initcontainer-env-configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "clusterpedia.mysql.storage.initContainer.env.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{ include "common.labels.standard" . | nindent 4 }}
+data:
+  STORAGE_HOST: {{ include "clusterpedia.mysql.storage.host" . | quote }}
+  STORAGE_PORT: {{ include "clusterpedia.mysql.storage.port" . | quote }}
+  STORAGE_USER: {{ include "clusterpedia.mysql.storage.user" . | quote }}
+  STORAGE_DATABASE: {{ include "clusterpedia.mysql.storage.database" . | quote }}
+  CREARE_DATABASE: {{ .Values.externalStorage.createDatabase | quote }}

--- a/charts/clusterpedia-mysql/values.yaml
+++ b/charts/clusterpedia-mysql/values.yaml
@@ -1,0 +1,140 @@
+## Default values for charts.
+## This is a YAML-formatted file.
+## Declare variables to be passed into your templates.
+
+## @param global clusterpedia global config
+global:
+  ## @param global.imageRegistry Global Docker image registry
+  imageRegistry: ""
+  ## E.g.
+  ## imagePullSecrets:
+  ##   - myRegistryKeySecretName
+  imagePullSecrets: []
+
+## @param storageInstallMode "internal" and "external" are provided
+## "internal" means automatic Database installation, default mysql
+## "external" means to install the database yourself, must specify the database connection parameters
+storageInstallMode: "internal"
+## @param installCRDs define flag whether to install or upgrade CRD resources
+##
+installCRDs: false
+## @param commonLabels Add labels to all the deployed resources (sub-charts are not considered). Evaluated as a template
+##
+commonLabels: {}
+## @param commonAnnotations Annotations to add to all deployed objects
+##
+commonAnnotations: {}
+## @param global.persistence.matchNode define the nodeAffinity of pv.
+## if PV resources are not required, set it to None!
+## if defined, will create the pv on the node.
+persistenceMatchNode: ""
+
+## @param storageConfig StorageConfig for the apiserver and clustersynchro manger
+##
+storageConfig:
+  ## @param storageConfig.log Config of clusterpedia log
+  log:
+    ## @param storageConfig.log.enabled indicates whether enable log
+    enabled: false
+    ## @param storageConfig.log.stdout indicates whether it is standard output
+    stdout: false
+    ## @param level indicates the level of log
+    ## Level must be one of [Silent, Error, Warn, Info], Default is 'Warn'
+    level: Warn
+    ## @param storageConfig.log.slowThreshold default 200ms
+    slowThreshold: 100ms
+    ## @param storageConfig.log.ignoreRecordNotFoundError indicates whether ignore error type `NotFound`
+    ignoreRecordNotFoundError: false
+    ## @param storageConfig.log.logger indicates the log rotate config
+    logger:
+      ## @param storageConfig.log.logger.filename indicates the file to write logs to
+      filename: /var/log/clusterpedia/internalstorage.log
+      ## @param storageConfig.log.logger.maxsize indicates the maximum size in megabytes of the log file before it gets
+      ## rotated
+      maxsize: 100
+      ## @param storageConfig.log.logger.maxbackups indicates the maximum number of old log files to retain. Default 0
+      ## is to retain all old log files
+      maxbackups: 0
+  ## @param storageConfig.connPool the connPoll config of storage
+  connPool:
+    ## @param storageConfig.connPool.maxIdleConns sets the maximum number of connections in the idle
+    ## connection pool
+    maxIdleConns: 5
+    ## @param storageConfig.connPool.maxOpenConns sets the maximum number of open connections to the database
+    maxOpenConns: 40
+    ## @param storageConfig.connPool.connMaxLifetime sets the maximum amount of time a connection may be reused
+    connMaxLifetime: 60m
+
+## @param external define the auth param of external database
+## if set the storageInstallMode to "external", the param must be set.
+externalStorage:
+  ## @param externalStorage.host for a custom host
+  ##
+  host: ""
+  ## @param externalStorage.port for a custom port
+  ##
+  port:
+  ## @param externalStorage.user Name for a custom user
+  ##
+  user: ""
+  ## @param externalStorage.password Password for a custom password
+  ##
+  password: ""
+  ## @param externalStorage.database Name for a custom database
+  ##
+  database: ""
+  ## @param externalStorage.createDatabase whether to create the .Values.externalStorage.database or not
+  ##
+  createDatabase: false
+
+## @section mysql Parameters
+##
+## mysql properties
+##
+mysql:
+  ## Properties for using an existing mysql installation
+  ## @param mysql.image.registry mysql image registry
+  ## @param mysql.image.repository mysql image repository
+  ## @param mysql.image.tag mysql image tag (immutable tags are recommended)
+  ## @param mysql.image.pullPolicy mysql image pull policy
+  ## @param mysql.image.pullSecrets Specify image pull secrets
+  ##
+  image:
+    registry: docker.io
+    repository: bitnami/mysql
+    tag: 8.0.28-debian-10-r23
+    ## Specify a imagePullPolicy
+    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+    ##
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## Example:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []
+  auth:
+    ## @param auth.rootPassword Password for the `root` user. Ignored if existing secret is provided
+    ##
+    rootPassword: "dangerous0"
+    ## @param auth.database Name for a custom database to create
+    ##
+    database: clusterpedia
+    ## @param auth.username Name for a custom user to create
+    ##
+    username: ""
+    ## @param auth.password Password for the new user. Ignored if existing secret is provided
+    ##
+    password: ""
+  ## @primary config
+  primary:
+    ## Enable persistence using Persistent Volume Claims
+    ##
+    persistence:
+      ## @param primary.persistence.enabled Enable persistence on MySQL primary replicas using a `PersistentVolumeClaim`. If false, use emptyDir
+      ##
+      enabled: true
+      ## @param primary.persistence.size MySQL primary persistent volume size
+      ##
+      size: 10Gi


### PR DESCRIPTION
Signed-off-by: calvin0327 <wen.chen@daocloud.io>
add mysql storage for clusterpedia
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md).

Changes are automatically published when merged to `main`. They are not published on branches.
