### PR TITLE
clusterpedia-core: update version to 0.1.1

### DIFF
--- a/charts/clusterpedia-core/Chart.yaml
+++ b/charts/clusterpedia-core/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/clusterpedia-mysql/Chart.yaml
+++ b/charts/clusterpedia-mysql/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -40,4 +40,4 @@ dependencies:
     version: 1.x.x
   - name: clusterpedia-core
     repository: https://clusterpedia-io.github.io/clusterpedia-helm/
-    version: 0.1.0
+    version: 0.1.x


### PR DESCRIPTION
Signed-off-by: Iceber Gu <wei.cai-nat@daocloud.io>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md).

Changes are automatically published when merged to `main`. They are not published on branches.
