### PR TITLE
clusterpedia: bump image tag to v0.6.0

### DIFF
--- a/charts/clusterpedia/Chart.yaml
+++ b/charts/clusterpedia/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.5.2"
+appVersion: "v0.6.0"
 
 sources:
   - "https://github.com/clusterpedia-io/clusterpedia-helm"

--- a/charts/clusterpedia/templates/clustersynchro-manager-deployment.yaml
+++ b/charts/clusterpedia/templates/clustersynchro-manager-deployment.yaml
@@ -83,6 +83,7 @@ spec:
         - /usr/local/bin/clustersynchro-manager
         - --storage-config=/etc/clusterpedia/storage/internalstorage-config.yaml
         - --leader-elect-resource-namespace={{ .Release.Namespace }}
+        - --worker-number={{ .Values.clustersynchroManager.workerNumber }}
         {{- with (include "clusterpedia.clustersynchroManager.featureGates" .) }}
         - {{ . }}
         {{- end }}

--- a/charts/clusterpedia/values.yaml
+++ b/charts/clusterpedia/values.yaml
@@ -122,7 +122,7 @@ apiserver:
   image:
     registry: ghcr.io
     repository: clusterpedia-io/clusterpedia/apiserver
-    tag: v0.5.2
+    tag: v0.6.0
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ##
@@ -153,18 +153,22 @@ apiserver:
   ## @param apiserver.tolerations
   tolerations: []
   ## @param featureGate to apiserver
-  featureGates:
+  featureGates: {}
     ## Allow apiservers to show a count of remaining items in the response to a chunking list request.
-    RemainingItemCount: false
+    ## RemainingItemCount: false
+
     ## @param AllowRawSQLQuery is a feature gate for the apiserver to allow querying by the raw sql.
     ## owner: @cleverhu
     ## alpha: v0.3.0
-    AllowRawSQLQuery: false
+    ## AllowRawSQLQuery: false
+
   ## @param apiserver.enableSHA1Cert specifies whether to allow SHA1 certificates for apiserver.
   enableSHA1Cert: false
 
 ## clustersynchro manager config
 clustersynchroManager:
+  ## @param clustersynchroManager.workerNumber set the number of workers
+  workerNumber: 5
   ## @param clustersynchroManager.labels
   labels: {}
   ## @param clustersynchroManager.replicaCount target replicas
@@ -182,7 +186,7 @@ clustersynchroManager:
   image:
     registry: ghcr.io
     repository: clusterpedia-io/clusterpedia/clustersynchro-manager
-    tag: v0.5.2
+    tag: v0.6.0
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ##
@@ -212,28 +216,33 @@ clustersynchroManager:
   ## @param clustersynchroManager.tolerations
   tolerations: []
   ## @param featureGate to clustersynchro
-  featureGates:
+  featureGates: {}
     ## @param PruneManagedFields is a feature gate for ClusterSynchro to prune `ManagedFields` of the resource
     ## owner: @iceber
     ## alpha: v0.0.9
     ## beta: v0.3.0
-    PruneManagedFields: true
+    ## PruneManagedFields: true
 
     ## @param PruneLastAppliedConfiguration is a feature gate for the ClusterSynchro to prune `LastAppliedConfiguration` of the resource
     ## owner: @iceber
     ## alpha: v0.0.9
     ## beta: v0.3.0
-    PruneLastAppliedConfiguration: true
+    ## PruneLastAppliedConfiguration: true
 
     ## @param AllowSyncAllCustomResources is a feature gate for the ClusterSynchro to allow syncing of all custom resources
     ## owner: @iceber
     ## alpha: v0.3.0
-    AllowSyncAllCustomResources: false
+    ## AllowSyncAllCustomResources: false
 
     ## @param AllowSyncAllResources is a feature gate for the ClusterSynchro to allow syncing of all resources
     ## owner: @iceber
     ## alpha: v0.3.0
-    AllowSyncAllResources: false
+    ## AllowSyncAllResources: false
+
+    ## HealthCheckerWithStandaloneTCP is a feature gate for the cluster health checker to use standalone tcp
+    ## owner: @iceber
+    ## alpha: v0.6.0
+    ## HealthCheckerWithStandaloneTCP: false
 
 ## controller manager config
 controllerManager:
@@ -254,7 +263,7 @@ controllerManager:
   image:
     registry: ghcr.io
     repository: clusterpedia-io/clusterpedia/controller-manager
-    tag: v0.5.2
+    tag: v0.6.0
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ##


### PR DESCRIPTION
Signed-off-by: Iceber Gu <wei.cai-nat@daocloud.io>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md).

Changes are automatically published when merged to `main`. They are not published on branches.
