### PR TITLE
clusterpedia-mysql: update Chart.lock

### DIFF
--- a/charts/clusterpedia-mysql/Chart.lock
+++ b/charts/clusterpedia-mysql/Chart.lock
@@ -8,5 +8,5 @@ dependencies:
 - name: clusterpedia-core
   repository: https://clusterpedia-io.github.io/clusterpedia-helm/
   version: 0.1.0
-digest: sha256:9e2334ce4505330dbdb7d460be53b484015984adc32e77c24b89bbdc2cce96e9
-generated: "2022-12-14T17:53:48.348695+08:00"
+digest: sha256:6d5d18f89239c3a286e0822ad8b6904d63067553d6a960b61a262b8e3374bec4
+generated: "2022-12-23T15:40:31.817123+08:00"


### PR DESCRIPTION
Signed-off-by: Iceber Gu <wei.cai-nat@daocloud.io>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md#documentation)
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md).

Changes are automatically published when merged to `main`. They are not published on branches.
