### PR TITLE
fix publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Add dependency chart repos
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add clusterpedia https://clusterpedia-io.github.io/clusterpedia-helm
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.4.1


### PR DESCRIPTION
Signed-off-by: Iceber Gu <wei.cai-nat@daocloud.io>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md#documentation)
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md).

Changes are automatically published when merged to `main`. They are not published on branches.
