### PR TITLE
fix resolve .local service domain

### DIFF
--- a/charts/clusterpedia/Chart.yaml
+++ b/charts/clusterpedia/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.0
+version: 1.6.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/clusterpedia/templates/apiserver-deployment.yaml
+++ b/charts/clusterpedia/templates/apiserver-deployment.yaml
@@ -134,7 +134,10 @@ spec:
               key: password
         {{- if .Values.apiserver.enableSHA1Cert }}
         - name: GODEBUG
-          value: x509sha1=1
+          value: netdns=go,x509sha1=1
+        {{- else }}
+        - name: GODEBUG
+          value: netdns=go
         {{- end }}
         volumeMounts:
         - name: internalstorage-config

--- a/charts/clusterpedia/templates/clustersynchro-manager-deployment.yaml
+++ b/charts/clusterpedia/templates/clustersynchro-manager-deployment.yaml
@@ -136,6 +136,8 @@ spec:
               secretKeyRef:
                 name: {{ include "clusterpedia.internalstorage.fullname" . }}
                 key: password
+          - name: GODEBUG
+            value: netdns=go
         volumeMounts:
           - name: internalstorage-config
             mountPath: /etc/clusterpedia/storage


### PR DESCRIPTION
https://pkg.go.dev/net#hdr-Name_Resolution

When cgo is enabled, if the domain name is `.local`, cgo will be called to resolve it, and then it will failed with `Failed to init storage: dial tcp: lookup clusterpedia-mysql.clusterpedia-system.svc.cluster.local: device or resource busy`

Now force `go resolver` to resolve the domain name, and in the future we can set this environment variable inside the program

Related PR: https://github.com/clusterpedia-io/clusterpedia/pull/524

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md).

Changes are automatically published when merged to `main`. They are not published on branches.
