### PR TITLE
clusterpedia: bump clusterpedia to 0.7.0

### DIFF
--- a/charts/clusterpedia/Chart.yaml
+++ b/charts/clusterpedia/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.3
+version: 1.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.6.3"
+appVersion: "v0.7.0"
 
 sources:
   - "https://github.com/clusterpedia-io/clusterpedia-helm"

--- a/charts/clusterpedia/values.yaml
+++ b/charts/clusterpedia/values.yaml
@@ -126,7 +126,7 @@ apiserver:
   image:
     registry: ghcr.io
     repository: clusterpedia-io/clusterpedia/apiserver
-    tag: v0.6.3
+    tag: v0.7.0
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ##
@@ -190,7 +190,7 @@ clustersynchroManager:
   image:
     registry: ghcr.io
     repository: clusterpedia-io/clusterpedia/clustersynchro-manager
-    tag: v0.6.3
+    tag: v0.7.0
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ##
@@ -277,7 +277,7 @@ controllerManager:
   image:
     registry: ghcr.io
     repository: clusterpedia-io/clusterpedia/controller-manager
-    tag: v0.6.3
+    tag: v0.7.0
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ##


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md).

Changes are automatically published when merged to `main`. They are not published on branches.
