### PR TITLE
clusterpedia: add clustersynchro manager metrics service

### DIFF
--- a/charts/clusterpedia/Chart.yaml
+++ b/charts/clusterpedia/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.7.3
+version: 1.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/clusterpedia/templates/_helpers.tpl
+++ b/charts/clusterpedia/templates/_helpers.tpl
@@ -23,6 +23,13 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s" (include "common.names.fullname" .) "controller-manager" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "clusterpedia.kubeStateMetrics.fullname" -}}
+{{- printf "%s-%s" (include "common.names.fullname" .) "kube-state-metrics" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 
 {{/*
 Return the proper apiserver image name

--- a/charts/clusterpedia/templates/clusterpedia-kube-state-metrics.yaml
+++ b/charts/clusterpedia/templates/clusterpedia-kube-state-metrics.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.clustersynchroManager.kubeStateMetrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "clusterpedia.kubeStateMetrics.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+spec:
+  ports:
+  - name: kube-state-metrics
+    port: 8080
+    targetPort: 8080
+  selector:
+    app: {{ include "clusterpedia.clustersynchroManager.fullname" . }}
+    {{- if .Values.clustersynchroManager.podLabels }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.clustersynchroManager.podLabels "context" $) | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/clusterpedia/templates/clustersynchro-manager-deployment.yaml
+++ b/charts/clusterpedia/templates/clustersynchro-manager-deployment.yaml
@@ -124,6 +124,9 @@ spec:
         - --leader-elect-retry-period={{ .Values.clustersynchroManager.leaderElect.retryPeriod }}
         - --leader-elect-resource-lock={{ .Values.clustersynchroManager.leaderElect.resourceLock }}
         - --worker-number={{ .Values.clustersynchroManager.workerNumber }}
+        {{- if .Values.clustersynchroManager.kubeStateMetrics.enabled }}
+        - --enable-kube-state-metrics
+        {{- end }}
         {{- with (include "clusterpedia.clustersynchroManager.featureGates" .) }}
         - {{ . }}
         {{- end }}

--- a/charts/clusterpedia/templates/clustersynchro-manager-metrics-service.yaml
+++ b/charts/clusterpedia/templates/clustersynchro-manager-metrics-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "clusterpedia.clustersynchroManager.fullname" . }}-metrics
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+spec:
+  ports:
+  - name: metrics
+    port: 8081
+    targetPort: 8081
+  selector:
+    app: {{ include "clusterpedia.clustersynchroManager.fullname" . }}
+    {{- if .Values.clustersynchroManager.podLabels }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.clustersynchroManager.podLabels "context" $) | nindent 4 }}
+    {{- end }}

--- a/charts/clusterpedia/values.yaml
+++ b/charts/clusterpedia/values.yaml
@@ -257,6 +257,8 @@ clustersynchroManager:
     renewDeadline: "10s"
     retryPeriod: "2s"
     resourceLock: "leases"
+  kubeStateMetrics:
+    enabled: false
 
 ## controller manager config
 controllerManager:


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md).

Changes are automatically published when merged to `main`. They are not published on branches.
