### PR TITLE
add disable switch to make controller-manager optional

### DIFF
--- a/charts/clusterpedia/Chart.yaml
+++ b/charts/clusterpedia/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.8.0
+version: 1.9.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/clusterpedia/templates/controller-manager-deployment.yaml
+++ b/charts/clusterpedia/templates/controller-manager-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.controllerManager.disabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -52,3 +53,4 @@ spec:
       {{- if .Values.controllerManager.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.controllerManager.tolerations "context" $) | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/charts/clusterpedia/templates/controller-manager-serviceaccount.yaml
+++ b/charts/clusterpedia/templates/controller-manager-serviceaccount.yaml
@@ -1,6 +1,8 @@
+{{- if not .Values.controllerManager.disabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "clusterpedia.controllerManager.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+{{- end }}

--- a/charts/clusterpedia/values.yaml
+++ b/charts/clusterpedia/values.yaml
@@ -310,6 +310,8 @@ controllerManager:
   tolerations: []
   ## @param featureGate to controller
   featureGates: {}
+  ## @param disabled
+  # disabled: true
 
 ## @section PostgreSQL Parameters
 ##


### PR DESCRIPTION
add disable switch to make controller-manager optional

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md#documentation)
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md).

Changes are automatically published when merged to `main`. They are not published on branches.
