### PR TITLE
Fix rendering template error when using a number as a db passwrod

### DIFF
--- a/charts/clusterpedia/Chart.yaml
+++ b/charts/clusterpedia/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.9.0
+version: 1.9.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/clusterpedia/templates/_helpers.tpl
+++ b/charts/clusterpedia/templates/_helpers.tpl
@@ -171,22 +171,22 @@ Return the proper Docker Image Registry Secret Names
 {{- define "clusterpedia.storage.password" -}}
 {{- if eq .Values.storageInstallMode "external" }}
      {{- if empty (include "clusterpedia.storage.dsn" .) -}}
-         {{- required "Please set correct storage password!" .Values.externalStorage.password | b64enc -}}
+         {{- required "Please set correct storage password!" .Values.externalStorage.password | toString | b64enc -}}
      {{- else -}}
-         {{- .Values.externalStorage.password | b64enc -}}
+         {{- .Values.externalStorage.password | toString | b64enc -}}
      {{- end -}}
 {{- else -}}
      {{- if eq (include "clusterpedia.storage.type" .) "postgres" }}
           {{- if not (empty .Values.global.postgresql.auth.username) -}}
-               {{- .Values.global.postgresql.auth.password | b64enc -}}
+               {{- .Values.global.postgresql.auth.password | toString | b64enc -}}
           {{- else -}}
-               {{- .Values.global.postgresql.auth.postgresPassword | b64enc -}}
+               {{- .Values.global.postgresql.auth.postgresPassword | toString | b64enc -}}
           {{- end -}}
      {{- else if eq (include "clusterpedia.storage.type" .) "mysql" -}}
           {{- if not (empty .Values.mysql.auth.username) -}}
-               {{- .Values.mysql.auth.password  | b64enc -}}
+               {{- .Values.mysql.auth.password | toString | b64enc -}}
           {{- else -}}
-               {{- .Values.mysql.auth.rootPassword | b64enc -}}
+               {{- .Values.mysql.auth.rootPassword | toString | b64enc -}}
           {{- end -}}
      {{- end -}}
 {{- end -}}


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md).

Changes are automatically published when merged to `main`. They are not published on branches.




```
#before

clusterpedia-helm % helm template  ./charts/clusterpedia  --set persistenceMatchNode=none --set storageInstallMode=external  --set externalStorage.type=mysql --set externalStorage.host="123" --set externalStorage.password=123 --set externalStorage.port=123 --set externalStorage.user=admin --set externalStorage.database=clusterpedia --set postgresql.enabled=false
Error: template: clusterpedia/templates/internalstorage-secret.yaml:10:15: executing "clusterpedia/templates/internalstorage-secret.yaml" at <include "clusterpedia.storage.password" .>: error calling include: template: clusterpedia/templates/_helpers.tpl:174:96: executing "clusterpedia.storage.password" at <b64enc>: wrong type for value; expected string; got int64

Use --debug flag to render out invalid YAML


# now
clusterpedia-helm % helm template  ./charts/clusterpedia  --set persistenceMatchNode=none --set storageInstallMode=external  --set externalStorage.type=mysql --set externalStorage.host="123" --set externalStorage.password=123 --set externalStorage.port=123 --set externalStorage.user=admin --set externalStorage.database=clusterpedia --set postgresql.enabled=false > helm.yaml
 clusterpedia-helm % echo $?
0

```

