### PR TITLE
add built-in db resources values

### DIFF
--- a/charts/clusterpedia/Chart.yaml
+++ b/charts/clusterpedia/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.9.1
+version: 1.9.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/clusterpedia/README.md
+++ b/charts/clusterpedia/README.md
@@ -177,6 +177,7 @@ rm /var/local/clusterpedia/internalstorage/<storage type>
 | mysql.image.tag | string | `"8.0.28-debian-10-r23"` |  |
 | mysql.primary.persistence.enabled | bool | `true` |  |
 | mysql.primary.persistence.size | string | `"10Gi"` |  |
+| mysql.primary.resources | object | `{}` |  |
 | persistenceMatchNode | string | `""` |  |
 | postgresql.enabled | bool | `true` |  |
 | postgresql.image.pullPolicy | string | `"IfNotPresent"` |  |
@@ -186,6 +187,7 @@ rm /var/local/clusterpedia/internalstorage/<storage type>
 | postgresql.image.tag | string | `"11.15.0-debian-10-r14"` |  |
 | postgresql.primary.persistence.enabled | bool | `true` |  |
 | postgresql.primary.persistence.size | string | `"10Gi"` |  |
+| postgresql.primary.resources | object | `{}` |  |
 | storageInstallMode | string | `"internal"` |  |
 
 ### StorageConfig
@@ -248,6 +250,7 @@ rm /var/local/clusterpedia/internalstorage/<storage type>
 | clustersynchroManager.image.registry | string | `"ghcr.io"` |  |
 | clustersynchroManager.image.repository | string | `"clusterpedia-io/clusterpedia/clustersynchro-manager"` |  |
 | clustersynchroManager.image.tag | string | `"v0.7.0"` |  |
+| clustersynchroManager.kubeStateMetrics.enabled | bool | `false` |  |
 | clustersynchroManager.labels | object | `{}` |  |
 | clustersynchroManager.leaderElect.leaseDuration | string | `"15s"` |  |
 | clustersynchroManager.leaderElect.renewDeadline | string | `"10s"` |  |

--- a/charts/clusterpedia/values.yaml
+++ b/charts/clusterpedia/values.yaml
@@ -354,6 +354,18 @@ postgresql:
       ## @param primary.persistence.size PVC Storage Request for PostgreSQL volume
       ##
       size: 10Gi
+    ## @param mysql.resources
+    ##
+    resources:
+      {}
+    # If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
 
 ## @section mysql Parameters
 ##
@@ -408,6 +420,18 @@ mysql:
       ## @param primary.persistence.size MySQL primary persistent volume size
       ##
       size: 10Gi
+    ## @param mysql.resources
+    ##
+    resources:
+      {}
+    # If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
 
 hookJob:
   image:


### PR DESCRIPTION


postgresql
```bash
helm template clusterpedia ./charts/clusterpedia  -n clusterpedia-system --set persistenceMatchNode=None --set postgresql.primary.resources.requests.cpu=1 --set postgresql.primary.resources.requests.memory=1G
```
```yaml
# Source: clusterpedia/charts/postgresql/templates/primary/statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: clusterpedia-postgresql
  namespace: "clusterpedia-system"
  labels:
    app.kubernetes.io/name: postgresql
    helm.sh/chart: postgresql-11.8.0
    app.kubernetes.io/instance: clusterpedia
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: primary
  annotations:
spec:
  replicas: 1
  serviceName: clusterpedia-postgresql-hl
  updateStrategy:
    rollingUpdate: {}
    type: RollingUpdate
  selector:
    matchLabels:
      app.kubernetes.io/name: postgresql
      app.kubernetes.io/instance: clusterpedia
      app.kubernetes.io/component: primary
  template:
    metadata:
      name: clusterpedia-postgresql
      labels:
        app.kubernetes.io/name: postgresql
        helm.sh/chart: postgresql-11.8.0
        app.kubernetes.io/instance: clusterpedia
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/component: primary
      annotations:
    spec:
      serviceAccountName: default
      
      affinity:
        podAffinity:
          
        podAntiAffinity:
          preferredDuringSchedulingIgnoredDuringExecution:
            - podAffinityTerm:
                labelSelector:
                  matchLabels:
                    app.kubernetes.io/name: postgresql
                    app.kubernetes.io/instance: clusterpedia
                    app.kubernetes.io/component: primary
                namespaces:
                  - "clusterpedia-system"
                topologyKey: kubernetes.io/hostname
              weight: 1
        nodeAffinity:
          
      securityContext:
        fsGroup: 1001
      hostNetwork: false
      hostIPC: false
      initContainers:
      containers:
        - name: postgresql
          image: docker.io/bitnami/postgresql:11.15.0-debian-10-r14
          imagePullPolicy: "IfNotPresent"
          securityContext:
            runAsUser: 1001
          env:
            - name: BITNAMI_DEBUG
              value: "false"
            - name: POSTGRESQL_PORT_NUMBER
              value: "5432"
            - name: POSTGRESQL_VOLUME_DIR
              value: "/bitnami/postgresql"
            - name: PGDATA
              value: "/bitnami/postgresql/data"
            # Authentication
            - name: POSTGRES_PASSWORD
              valueFrom:
                secretKeyRef:
                  name: clusterpedia-postgresql
                  key: postgres-password
            - name: POSTGRES_DB
              value: "clusterpedia"
            # Replication
            # Initdb
            # Standby
            # LDAP
            - name: POSTGRESQL_ENABLE_LDAP
              value: "no"
            # TLS
            - name: POSTGRESQL_ENABLE_TLS
              value: "no"
            # Audit
            - name: POSTGRESQL_LOG_HOSTNAME
              value: "false"
            - name: POSTGRESQL_LOG_CONNECTIONS
              value: "false"
            - name: POSTGRESQL_LOG_DISCONNECTIONS
              value: "false"
            - name: POSTGRESQL_PGAUDIT_LOG_CATALOG
              value: "off"
            # Others
            - name: POSTGRESQL_CLIENT_MIN_MESSAGES
              value: "error"
            - name: POSTGRESQL_SHARED_PRELOAD_LIBRARIES
              value: "pgaudit"
          ports:
            - name: tcp-postgresql
              containerPort: 5432
          livenessProbe:
            failureThreshold: 6
            initialDelaySeconds: 30
            periodSeconds: 10
            successThreshold: 1
            timeoutSeconds: 5
            exec:
              command:
                - /bin/sh
                - -c
                - exec pg_isready -U "postgres" -d "dbname=clusterpedia" -h 127.0.0.1 -p 5432
          readinessProbe:
            failureThreshold: 6
            initialDelaySeconds: 5
            periodSeconds: 10
            successThreshold: 1
            timeoutSeconds: 5
            exec:
              command:
                - /bin/sh
                - -c
                - -e
                
                - |
                  exec pg_isready -U "postgres" -d "dbname=clusterpedia" -h 127.0.0.1 -p 5432
                  [ -f /opt/bitnami/postgresql/tmp/.initialized ] || [ -f /bitnami/postgresql/.initialized ]
          resources:
            limits: {}
            requests:
              cpu: 1
              memory: 1G
          volumeMounts:
            - name: dshm
              mountPath: /dev/shm
            - name: data
              mountPath: /bitnami/postgresql
      volumes:
        - name: dshm
          emptyDir:
            medium: Memory
  volumeClaimTemplates:
    - metadata:
        name: data
      spec:
        accessModes:
          - "ReadWriteOnce"
        resources:
          requests:
            storage: "10Gi"

```
mysql 

```bash
helm template clusterpedia ./charts/clusterpedia  -n clusterpedia-system --set mysql.enabled=true --set postgresql.enabled=false --set persistenceMatchNode=None --set mysql.primary.resources.requests.cpu=1 --set mysql.primary.resources.requests.memory=1G
```


```yaml
# Source: clusterpedia/charts/mysql/templates/primary/statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: clusterpedia-mysql
  namespace: "clusterpedia-system"
  labels:
    app.kubernetes.io/name: mysql
    helm.sh/chart: mysql-9.3.0
    app.kubernetes.io/instance: clusterpedia
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: primary
spec:
  replicas: 1
  podManagementPolicy: ""
  selector:
    matchLabels: 
      app.kubernetes.io/name: mysql
      app.kubernetes.io/instance: clusterpedia
      app.kubernetes.io/component: primary
  serviceName: clusterpedia-mysql
  updateStrategy:
    type: RollingUpdate
  template:
    metadata:
      annotations:
        checksum/configuration: 68ffed9af861f5eb00b9fdcd4431fde06b7568c9abf3e3aa5594d1f9dc9c8878
      labels:
        app.kubernetes.io/name: mysql
        helm.sh/chart: mysql-9.3.0
        app.kubernetes.io/instance: clusterpedia
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/component: primary
    spec:
      serviceAccountName: clusterpedia-mysql
      
      affinity:
        podAffinity:
          
        podAntiAffinity:
          preferredDuringSchedulingIgnoredDuringExecution:
            - podAffinityTerm:
                labelSelector:
                  matchLabels:
                    app.kubernetes.io/name: mysql
                    app.kubernetes.io/instance: clusterpedia
                namespaces:
                  - "clusterpedia-system"
                topologyKey: kubernetes.io/hostname
              weight: 1
        nodeAffinity:
          
      securityContext:
        fsGroup: 1001
      initContainers:
      containers:
        - name: mysql
          image: docker.io/bitnami/mysql:8.0.28-debian-10-r23
          imagePullPolicy: "IfNotPresent"
          securityContext:
            runAsNonRoot: true
            runAsUser: 1001
          env:
            - name: BITNAMI_DEBUG
              value: "false"
            - name: MYSQL_ROOT_PASSWORD
              valueFrom:
                secretKeyRef:
                  name: clusterpedia-mysql
                  key: mysql-root-password
            - name: MYSQL_DATABASE
              value: "clusterpedia"
          envFrom:
          ports:
            - name: mysql
              containerPort: 3306
          livenessProbe:
            failureThreshold: 3
            initialDelaySeconds: 5
            periodSeconds: 10
            successThreshold: 1
            timeoutSeconds: 1
            exec:
              command:
                - /bin/bash
                - -ec
                - |
                  password_aux="${MYSQL_ROOT_PASSWORD:-}"
                  if [[ -f "${MYSQL_ROOT_PASSWORD_FILE:-}" ]]; then
                      password_aux=$(cat "$MYSQL_ROOT_PASSWORD_FILE")
                  fi
                  mysqladmin status -uroot -p"${password_aux}"
          readinessProbe:
            failureThreshold: 3
            initialDelaySeconds: 5
            periodSeconds: 10
            successThreshold: 1
            timeoutSeconds: 1
            exec:
              command:
                - /bin/bash
                - -ec
                - |
                  password_aux="${MYSQL_ROOT_PASSWORD:-}"
                  if [[ -f "${MYSQL_ROOT_PASSWORD_FILE:-}" ]]; then
                      password_aux=$(cat "$MYSQL_ROOT_PASSWORD_FILE")
                  fi
                  mysqladmin status -uroot -p"${password_aux}"
          startupProbe:
            failureThreshold: 10
            initialDelaySeconds: 15
            periodSeconds: 10
            successThreshold: 1
            timeoutSeconds: 1
            exec:
              command:
                - /bin/bash
                - -ec
                - |
                  password_aux="${MYSQL_ROOT_PASSWORD:-}"
                  if [[ -f "${MYSQL_ROOT_PASSWORD_FILE:-}" ]]; then
                      password_aux=$(cat "$MYSQL_ROOT_PASSWORD_FILE")
                  fi
                  mysqladmin status -uroot -p"${password_aux}"
          resources: 
            limits: {}
            requests:
              cpu: 1
              memory: 1G
          volumeMounts:
            - name: data
              mountPath: /bitnami/mysql
            - name: config
              mountPath: /opt/bitnami/mysql/conf/my.cnf
              subPath: my.cnf
      volumes:
        - name: config
          configMap:
            name: clusterpedia-mysql
  volumeClaimTemplates:
    - metadata:
        name: data
        labels: 
          app.kubernetes.io/name: mysql
          app.kubernetes.io/instance: clusterpedia
          app.kubernetes.io/component: primary
        annotations:
      spec:
        accessModes:
          - "ReadWriteOnce"
        resources:
          requests:
            storage: "10Gi"
---

```


Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md).

Changes are automatically published when merged to `main`. They are not published on branches.
