### PR TITLE
add OTEL trace env for helm chart

### DIFF
--- a/charts/clusterpedia/Chart.yaml
+++ b/charts/clusterpedia/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.0
+version: 2.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/clusterpedia/README.md
+++ b/charts/clusterpedia/README.md
@@ -228,13 +228,14 @@ rm /var/local/clusterpedia/internalstorage/<storage type>
 | apiserver.image.pullSecrets | list | `[]` |  |
 | apiserver.image.registry | string | `"ghcr.io"` |  |
 | apiserver.image.repository | string | `"clusterpedia-io/clusterpedia/apiserver"` |  |
-| apiserver.image.tag | string | `"v0.7.0"` |  |
+| apiserver.image.tag | string | `"v0.7.1"` |  |
 | apiserver.labels | object | `{}` |  |
 | apiserver.nodeSelector | object | `{}` |  |
 | apiserver.podAnnotations | object | `{}` |  |
 | apiserver.podLabels | object | `{}` |  |
 | apiserver.replicaCount | int | `1` |  |
 | apiserver.resources | object | `{}` |  |
+| apiserver.telemetry.tracing | object | `{}` |  |
 | apiserver.tolerations | list | `[]` |  |
 
 ### ClustersynchroManager
@@ -247,7 +248,8 @@ rm /var/local/clusterpedia/internalstorage/<storage type>
 | clustersynchroManager.image.pullSecrets | list | `[]` |  |
 | clustersynchroManager.image.registry | string | `"ghcr.io"` |  |
 | clustersynchroManager.image.repository | string | `"clusterpedia-io/clusterpedia/clustersynchro-manager"` |  |
-| clustersynchroManager.image.tag | string | `"v0.7.0"` |  |
+| clustersynchroManager.image.tag | string | `"v0.7.1"` |  |
+| clustersynchroManager.kubeStateMetrics.enabled | bool | `false` |  |
 | clustersynchroManager.labels | object | `{}` |  |
 | clustersynchroManager.leaderElect.leaseDuration | string | `"15s"` |  |
 | clustersynchroManager.leaderElect.renewDeadline | string | `"10s"` |  |
@@ -271,7 +273,7 @@ rm /var/local/clusterpedia/internalstorage/<storage type>
 | controllerManager.image.pullSecrets | list | `[]` |  |
 | controllerManager.image.registry | string | `"ghcr.io"` |  |
 | controllerManager.image.repository | string | `"clusterpedia-io/clusterpedia/controller-manager"` |  |
-| controllerManager.image.tag | string | `"v0.7.0"` |  |
+| controllerManager.image.tag | string | `"v0.7.1"` |  |
 | controllerManager.labels | object | `{}` |  |
 | controllerManager.nodeSelector | object | `{}` |  |
 | controllerManager.podAnnotations | object | `{}` |  |

--- a/charts/clusterpedia/templates/_helpers.tpl
+++ b/charts/clusterpedia/templates/_helpers.tpl
@@ -361,3 +361,31 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "clusterpedia.hookJob.image" -}}
 {{ include "common.images.image" (dict "imageRoot" .Values.hookJob.image "global" .Values.global) }}
 {{- end -}}
+
+{{- define "clusterpedia.apiserver.tracing.env" -}}
+{{- if .Values.apiserver.telemetry.tracing.addOtelEnv }}
+{{- if not (empty .Values.apiserver.telemetry.tracing.endpoint) }}
+- name: OTEL_EXPORTER_OTLP_ENDPOINT
+  value: {{ .Values.apiserver.telemetry.tracing.endpoint }}
+{{- end }}
+- name: OTEL_SERVICE_NAME
+  value: {{ include "common.names.fullname" . }}-apiserver
+- name: OTEL_K8S_NAMESPACE
+  valueFrom:
+    fieldRef:
+      apiVersion: v1
+      fieldPath: metadata.namespace
+- name: OTEL_RESOURCE_ATTRIBUTES_NODE_NAME
+  valueFrom:
+    fieldRef:
+      apiVersion: v1
+      fieldPath: spec.nodeName
+- name: OTEL_RESOURCE_ATTRIBUTES_POD_NAME
+  valueFrom:
+    fieldRef:
+      apiVersion: v1
+      fieldPath: metadata.name
+- name: OTEL_RESOURCE_ATTRIBUTES
+  value: 'k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)'
+{{- end -}}
+{{- end -}}

--- a/charts/clusterpedia/templates/apiserver-deployment.yaml
+++ b/charts/clusterpedia/templates/apiserver-deployment.yaml
@@ -119,6 +119,9 @@ spec:
         - /usr/local/bin/apiserver
         - --secure-port=443
         - --storage-config=/etc/clusterpedia/storage/internalstorage-config.yaml
+        {{- if or (not (empty .Values.apiserver.telemetry.tracing.endpoint)) (not (empty .Values.apiserver.telemetry.tracing.samplingRatePerMillion)) }}
+        - --tracing-config-file=/etc/clusterpedia/trace/tracing-config.yaml
+        {{- end }}
         {{- with (include "clusterpedia.apiserver.featureGates" .) }}
         - {{ . }}
         {{- end }}
@@ -132,6 +135,7 @@ spec:
             secretKeyRef:
               name: {{ include "clusterpedia.internalstorage.fullname" . }}
               key: password
+        {{- include "clusterpedia.apiserver.tracing.env" . | nindent 8 }}
         {{- if .Values.apiserver.enableSHA1Cert }}
         - name: GODEBUG
           value: netdns=go,x509sha1=1
@@ -143,6 +147,11 @@ spec:
         - name: internalstorage-config
           mountPath: /etc/clusterpedia/storage
           readOnly: true
+        {{- if or (not (empty .Values.apiserver.telemetry.tracing.endpoint)) (not (empty .Values.apiserver.telemetry.tracing.samplingRatePerMillion)) }}
+        - name: tracing-config
+          mountPath: /etc/clusterpedia/trace
+          readOnly: true
+        {{- end }}
       serviceAccountName: {{ include "clusterpedia.apiserver.fullname" . }}
       {{- if .Values.apiserver.affinity }}
       affinity: {{- include "common.tplvalues.render" (dict "value" .Values.apiserver.affinity "context" $) | nindent 8 }}
@@ -160,3 +169,8 @@ spec:
         - name: scripts
           configMap:
             name: {{ include "clusterpedia.scripts.fullname" . }}
+        {{- if or (not (empty .Values.apiserver.telemetry.tracing.endpoint)) (not (empty .Values.apiserver.telemetry.tracing.samplingRatePerMillion)) }}
+        - name: tracing-config
+          configMap:
+            name: {{ include "clusterpedia.apiserver.fullname" .}}-tracing-config
+        {{- end }}

--- a/charts/clusterpedia/templates/apiserver-tracing-config.yaml
+++ b/charts/clusterpedia/templates/apiserver-tracing-config.yaml
@@ -1,0 +1,17 @@
+{{- if or (not (empty .Values.apiserver.telemetry.tracing.endpoint)) (not (empty .Values.apiserver.telemetry.tracing.samplingRatePerMillion)) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "clusterpedia.apiserver.fullname" .}}-tracing-config
+  namespace: {{ .Release.Namespace }}
+data:
+  tracing-config.yaml: |
+    apiVersion: apiserver.config.k8s.io/v1beta1
+    kind: TracingConfiguration
+    {{- if not (empty .Values.apiserver.telemetry.tracing.endpoint) }}
+    endpoint: {{ .Values.apiserver.telemetry.tracing.endpoint }}
+    {{- end -}}
+    {{- if not (empty .Values.apiserver.telemetry.tracing.samplingRatePerMillion) }}
+    samplingRatePerMillion: {{ .Values.apiserver.telemetry.tracing.samplingRatePerMillion }}
+    {{- end -}}
+{{- end }}

--- a/charts/clusterpedia/values.yaml
+++ b/charts/clusterpedia/values.yaml
@@ -166,8 +166,19 @@ apiserver:
     ## alpha: v0.3.0
     ## AllowRawSQLQuery: false
 
+    ## @param APIServerTracing add support for distributed tracing in the API Server
+    ## APIServerTracing: true
+
   ## @param apiserver.enableSHA1Cert specifies whether to allow SHA1 certificates for apiserver.
   enableSHA1Cert: false
+
+  ## @param telemetry define flag whether to enable otel trace
+  ##
+  telemetry:
+    tracing:
+      endpoint: ""   # example "localhost:4317"
+      samplingRatePerMillion: 0  # example 1000000, the number of samples to collect per million spans
+      addOtelEnv: false
 
 ## clustersynchro manager config
 clustersynchroManager:


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md).

Changes are automatically published when merged to `main`. They are not published on branches.
