### PR TITLE
update clusterpedia to 0.7.1

### DIFF
--- a/charts/clusterpedia/Chart.yaml
+++ b/charts/clusterpedia/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.0
+version: 2.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.7.0"
+appVersion: "v0.7.1"
 
 sources:
   - "https://github.com/clusterpedia-io/clusterpedia-helm"

--- a/charts/clusterpedia/values.yaml
+++ b/charts/clusterpedia/values.yaml
@@ -126,7 +126,7 @@ apiserver:
   image:
     registry: ghcr.io
     repository: clusterpedia-io/clusterpedia/apiserver
-    tag: v0.7.0
+    tag: v0.7.1
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ##
@@ -190,7 +190,7 @@ clustersynchroManager:
   image:
     registry: ghcr.io
     repository: clusterpedia-io/clusterpedia/clustersynchro-manager
-    tag: v0.7.0
+    tag: v0.7.1
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ##
@@ -243,10 +243,17 @@ clustersynchroManager:
     ## alpha: v0.3.0
     ## AllowSyncAllResources: false
 
-    ## HealthCheckerWithStandaloneTCP is a feature gate for the cluster health checker to use standalone tcp
+    ## @param HealthCheckerWithStandaloneTCP is a feature gate for the cluster health checker to use standalone tcp
     ## owner: @iceber
     ## alpha: v0.6.0
     ## HealthCheckerWithStandaloneTCP: false
+
+    ## @param IgnoreSyncLease is a feature gate for the ClusterSynchro to skip syncing leases.coordination.k8s.io,
+    ## if you enable this feature, these resources will not be synced no matter what `syncResources` are defined.
+    ## owner: @27149chen
+    ## alpha: v0.8.0
+    ## IgnoreSyncLease: false
+
   ## @param clustersynchroManager.leaderElect.leaseDuration the duration that non-leader candidates will wait after observing a leadership renewal
   ## @param clustersynchroManager.leaderElect.renewDeadline the interval between attempts by the acting master to renew a leadership slot before it stops leading
   ## @param clustersynchroManager.leaderElect.retryPeriod the duration the clients should wait between attempting acquisition and renewal of a leadership
@@ -279,7 +286,7 @@ controllerManager:
   image:
     registry: ghcr.io
     repository: clusterpedia-io/clusterpedia/controller-manager
-    tag: v0.7.0
+    tag: v0.7.1
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ##


### PR DESCRIPTION
update clusterpedia to 0.7.1

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md#documentation)
* [ ] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md).

Changes are automatically published when merged to `main`. They are not published on branches.
