### PR TITLE
clusterpedia: bump clusterpedia to 0.8.0

### DIFF
--- a/charts/clusterpedia/Chart.yaml
+++ b/charts/clusterpedia/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.0
+version: 2.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.7.1"
+appVersion: "v0.8.0"
 
 sources:
   - "https://github.com/clusterpedia-io/clusterpedia-helm"

--- a/charts/clusterpedia/values.yaml
+++ b/charts/clusterpedia/values.yaml
@@ -126,7 +126,7 @@ apiserver:
   image:
     registry: ghcr.io
     repository: clusterpedia-io/clusterpedia/apiserver
-    tag: v0.7.1
+    tag: v0.8.0
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ##
@@ -201,7 +201,7 @@ clustersynchroManager:
   image:
     registry: ghcr.io
     repository: clusterpedia-io/clusterpedia/clustersynchro-manager
-    tag: v0.7.1
+    tag: v0.8.0
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ##
@@ -265,6 +265,19 @@ clustersynchroManager:
     ## alpha: v0.8.0
     ## IgnoreSyncLease: false
 
+    ## @param ForcePaginatedListForResourceSync is a feature gate for ResourceSync's reflector to force paginated list,
+    ## reflector will sometimes use APIServer's cache, even if paging is specified APIServer will return all resources for performance,
+    ## then it will skip Reflector's streaming memory optimization.
+    ## owner: @iceber
+    ## alpha: v0.8.0
+    ## ForcePaginatedListForResourceSync featuregate.Feature = "ForcePaginatedListForResourceSync"
+
+    ## StreamHandlePaginatedListForResourceSync is a feature gate for ResourceSync's reflector to handle echo paginated resources,
+    ## resources within a pager will be processed as soon as possible instead of waiting until all resources are pulled before calling the ResourceHandler.
+    ## owner: @iceber
+    ## alpha: v0.8.0
+    ## StreamHandlePaginatedListForResourceSync featuregate.Feature = "StreamHandlePaginatedListForResourceSync"
+
   ## @param clustersynchroManager.leaderElect.leaseDuration the duration that non-leader candidates will wait after observing a leadership renewal
   ## @param clustersynchroManager.leaderElect.renewDeadline the interval between attempts by the acting master to renew a leadership slot before it stops leading
   ## @param clustersynchroManager.leaderElect.retryPeriod the duration the clients should wait between attempting acquisition and renewal of a leadership
@@ -297,7 +310,7 @@ controllerManager:
   image:
     registry: ghcr.io
     repository: clusterpedia-io/clusterpedia/controller-manager
-    tag: v0.7.1
+    tag: v0.8.0
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ##


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md#documentation)
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md).

Changes are automatically published when merged to `main`. They are not published on branches.
