### PR TITLE
Fix clustersynchro manager create db failure when using dsn

### DIFF
--- a/charts/clusterpedia/Chart.yaml
+++ b/charts/clusterpedia/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.0
+version: 2.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/clusterpedia/templates/clustersynchro-manager-deployment.yaml
+++ b/charts/clusterpedia/templates/clustersynchro-manager-deployment.yaml
@@ -41,7 +41,7 @@ spec:
             # Load YAML data into a Bash variable
             source /opt/scripts/parse-yaml.sh;
             create_variables /etc/clusterpedia/storage/internalstorage-config.yaml;
-            until psql -U ${user} -h ${host} -p ${port} postgres -c "SELECT 1 FROM pg_database WHERE datname = '{{ include "clusterpedia.storage.database" . }}'" | grep -q 1 || psql -U ${user} -h ${host} -p ${port} postgres -c "CREATE DATABASE {{ include "clusterpedia.storage.database" . }} owner ${user} " -c "GRANT ALL PRIVILEGES ON DATABASE {{ include "clusterpedia.storage.database" . }} to ${user} "; do 
+            until psql -U ${user} -h ${host} -p ${port} postgres -c "SELECT 1 FROM pg_database WHERE datname = ${database}" | grep -q 1 || psql -U ${user} -h ${host} -p ${port} postgres -c "CREATE DATABASE ${database} owner ${user} " -c "GRANT ALL PRIVILEGES ON DATABASE ${database} to ${user}"; do
             echo waiting for database check && sleep 1;
             done;
             echo 'DataBase OK ✓'
@@ -51,8 +51,8 @@ spec:
             source /opt/scripts/parse-yaml.sh;
             create_variables /etc/clusterpedia/storage/internalstorage-config.yaml;
             if [ -z $password ]; then password=${DB_PASSWORD}; fi;
-            until mysql -u${user} -p${password} --host=${host} --port=${port} -e 'CREATE DATABASE IF NOT EXISTS {{ include "clusterpedia.storage.database" . }}'; do
-            echo waiting for database check && sleep 1; 
+            until mysql -u${user} -p${password} --host=${host} --port=${port} -e "CREATE DATABASE IF NOT EXISTS ${database}"; do
+            echo waiting for database check && sleep 1;
             done;
             echo 'DataBase OK ✓'
           {{- end }}


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md).

Changes are automatically published when merged to `main`. They are not published on branches.
