### PR TITLE
add service monitor for clustersynchro-manager

### DIFF
--- a/charts/clusterpedia/Chart.yaml
+++ b/charts/clusterpedia/Chart.yaml
@@ -21,7 +21,7 @@ version: 2.2.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.7.1"
+appVersion: "v0.7.2"
 
 sources:
   - "https://github.com/clusterpedia-io/clusterpedia-helm"

--- a/charts/clusterpedia/templates/clustersynchro-manager-metrics-service.yaml
+++ b/charts/clusterpedia/templates/clustersynchro-manager-metrics-service.yaml
@@ -3,7 +3,9 @@ kind: Service
 metadata:
   name: {{ include "clusterpedia.clustersynchroManager.fullname" . }}-metrics
   namespace: {{ .Release.Namespace }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  labels:
+    app: {{ include "clusterpedia.clustersynchroManager.fullname" . }}
+    {{- include "common.labels.standard" . | nindent 4 }}
 spec:
   ports:
   - name: metrics

--- a/charts/clusterpedia/templates/clustersynchro-manager-service-monitor.yaml
+++ b/charts/clusterpedia/templates/clustersynchro-manager-service-monitor.yaml
@@ -1,0 +1,20 @@
+{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1/ServiceMonitor" }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "clusterpedia.clustersynchroManager.fullname" . }}-service-monitor
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "clusterpedia.clustersynchroManager.fullname" . }}
+    {{- if .Values.clustersynchroManager.serviceMonitor.labels }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.clustersynchroManager.serviceMonitor.labels "context" $) | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ include "clusterpedia.clustersynchroManager.fullname" . }}
+      {{- include "common.labels.standard" . | nindent 6 }}
+  endpoints:
+    - port: metrics
+      path: /metrics
+{{- end }}

--- a/charts/clusterpedia/values.yaml
+++ b/charts/clusterpedia/values.yaml
@@ -277,6 +277,8 @@ clustersynchroManager:
     resourceLock: "leases"
   kubeStateMetrics:
     enabled: false
+  serviceMonitor:
+    labels: {}
 
 ## controller manager config
 controllerManager:


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md).

Changes are automatically published when merged to `main`. They are not published on branches.
