### PR TITLE
Add clusterpedia crd sync ci

### DIFF
--- a/.github/workflows/lint-crd-sync.yaml
+++ b/.github/workflows/lint-crd-sync.yaml
@@ -1,0 +1,45 @@
+# validate any chart changes under charts directory
+name: Clusterpedia crd sync
+
+env:
+  CLUSTERPEDIA_REPO: https://github.com/clusterpedia-io/clusterpedia.git
+  TMP_DIR: /tmp/clusterpedia
+  CLUSTERPEDIA_CRD_DIR: deploy/crds
+  CLSUTERPEDIA_HELM_CRD_DIR: charts/clusterpedia/_crds
+  CHART_YAML_PATH: charts/clusterpedia/Chart.yaml
+  IGNORE_MATCHING_LINES: "helm.sh/resource-policy: keep"
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  crd-sync-check:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Lookup clusterpedia version
+      run: |
+        APP_VERSION=$(yq '.appVersion' < ${{ env.CHART_YAML_PATH }})
+        echo "APP_VERSION=${APP_VERSION,,}" >> ${GITHUB_ENV}
+    - name: Pull clusterpedia code
+      run: |
+        echo "chart appVersion: ${{ env.APP_VERSION }}"
+        echo "pull clusterpedia from https://github.com/clusterpedia-io/clusterpedia.git"
+        git clone --single-branch --depth 1 --branch ${{ env.APP_VERSION }} ${{ env.CLUSTERPEDIA_REPO }} ${{ env.TMP_DIR }}
+    - name: check whether crd is sync 
+      run: |
+        ret=0
+        diff -Naupr -I '${{ env.IGNORE_MATCHING_LINES }}' ${{ env.CLSUTERPEDIA_HELM_CRD_DIR }} ${{ env.TMP_DIR }}/${{ env.CLUSTERPEDIA_CRD_DIR }} || ret=$?
+        if [[ $ret -eq 1 ]]
+        then
+          echo "clusterpedia crd has been change, please update synchronouly this repo crd resource."
+          exit 1
+        fi
+    - name: cleanup
+      run: |
+        echo "remove clusterpedia code"
+        rm ${{ env.TMP_DIR }} -rf

--- a/.github/workflows/lint-crd-sync.yaml
+++ b/.github/workflows/lint-crd-sync.yaml
@@ -4,7 +4,7 @@ name: Clusterpedia crd sync
 env:
   CLUSTERPEDIA_REPO: https://github.com/clusterpedia-io/clusterpedia.git
   TMP_DIR: /tmp/clusterpedia
-  CLUSTERPEDIA_CRD_DIR: deploy/crds
+  CLUSTERPEDIA_CRD_DIR: kustomize/crds
   CLSUTERPEDIA_HELM_CRD_DIR: charts/clusterpedia/_crds
   CHART_YAML_PATH: charts/clusterpedia/Chart.yaml
   IGNORE_MATCHING_LINES: "helm.sh/resource-policy: keep"
@@ -33,7 +33,7 @@ jobs:
     - name: check whether crd is sync 
       run: |
         ret=0
-        diff -Naupr -I '${{ env.IGNORE_MATCHING_LINES }}' ${{ env.CLSUTERPEDIA_HELM_CRD_DIR }} ${{ env.TMP_DIR }}/${{ env.CLUSTERPEDIA_CRD_DIR }} || ret=$?
+        diff -Naupr --exclude=kustomization.yaml -I '${{ env.IGNORE_MATCHING_LINES }}' ${{ env.CLSUTERPEDIA_HELM_CRD_DIR }} ${{ env.TMP_DIR }}/${{ env.CLUSTERPEDIA_CRD_DIR }} || ret=$?
         if [[ $ret -eq 1 ]]
         then
           echo "clusterpedia crd has been change, please update synchronouly this repo crd resource."


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

related pr: https://github.com/clusterpedia-io/clusterpedia-helm/pull/17

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/clusterpedia-io/clusterpedia-helm/blob/main/CONTRIBUTING.md).

Changes are automatically published when merged to `main`. They are not published on branches.
